### PR TITLE
Add example: Build an Email Agent with AgentMail

### DIFF
--- a/examples/Email_agent_with_AgentMail.ipynb
+++ b/examples/Email_agent_with_AgentMail.ipynb
@@ -1,0 +1,335 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Build an Email Agent with AgentMail\n",
+        "\n",
+        "This notebook shows how to build an AI agent that can send, receive, and reply to emails using [AgentMail](https://agentmail.to) — the email API built for AI agents.\n",
+        "\n",
+        "Unlike traditional email APIs (SendGrid, SES) which focus on one-way sending, AgentMail gives agents their own email inboxes with full two-way communication: send, receive, reply, forward, manage threads, and process attachments.\n",
+        "\n",
+        "## What you'll build\n",
+        "\n",
+        "An AI customer support agent that:\n",
+        "1. Gets its own email inbox\n",
+        "2. Receives customer emails\n",
+        "3. Uses GPT-4 to understand the request and generate a response\n",
+        "4. Replies to the customer via email\n",
+        "\n",
+        "## Prerequisites\n",
+        "\n",
+        "- OpenAI API key\n",
+        "- AgentMail API key (free at [console.agentmail.to](https://console.agentmail.to))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!pip install openai agentmail"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "from openai import OpenAI\n",
+        "from agentmail import AgentMail\n",
+        "\n",
+        "openai_client = OpenAI(api_key=os.environ[\"OPENAI_API_KEY\"])\n",
+        "agentmail_client = AgentMail(api_key=os.environ[\"AGENTMAIL_API_KEY\"])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 1: Create an inbox for your agent\n",
+        "\n",
+        "Each agent gets its own unique email address. You can create as many inboxes as you need — one per agent, per customer, or per conversation."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "inbox = agentmail_client.inboxes.create(\n",
+        "    display_name=\"Support Agent\"\n",
+        ")\n",
+        "print(f\"Agent email: {inbox.inbox_id}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 2: Send an email from your agent\n",
+        "\n",
+        "Your agent can send emails to anyone. The email comes from the agent's own inbox address."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "message = agentmail_client.inboxes.messages.send(\n",
+        "    inbox_id=inbox.inbox_id,\n",
+        "    to=\"customer@example.com\",\n",
+        "    subject=\"Welcome! How can I help?\",\n",
+        "    text=\"Hi there! I'm your AI support agent. Reply to this email with any questions and I'll help you out.\"\n",
+        ")\n",
+        "print(f\"Sent message: {message.message_id}\")\n",
+        "print(f\"Thread: {message.thread_id}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 3: Check for incoming emails\n",
+        "\n",
+        "List messages in the inbox to see replies. In production, you'd use webhooks or WebSockets for real-time processing."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "messages = agentmail_client.inboxes.messages.list(inbox_id=inbox.inbox_id)\n",
+        "\n",
+        "for msg in messages.messages:\n",
+        "    print(f\"From: {msg.from_}\")\n",
+        "    print(f\"Subject: {msg.subject}\")\n",
+        "    # Use extracted_text to get just the new content (strips quoted replies)\n",
+        "    content = msg.extracted_text or msg.text\n",
+        "    print(f\"Content: {content}\")\n",
+        "    print(\"---\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 4: Build the AI email agent\n",
+        "\n",
+        "Now let's combine OpenAI and AgentMail into a working support agent. This function:\n",
+        "1. Reads new incoming emails\n",
+        "2. Uses GPT-4 to generate a contextual reply\n",
+        "3. Sends the reply via AgentMail\n",
+        "4. Uses `extracted_text` to handle email chains cleanly"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "SYSTEM_PROMPT = \"\"\"You are a helpful customer support agent for a SaaS product.\n",
+        "Reply to customer emails concisely and helpfully.\n",
+        "If you don't know the answer, say so and offer to escalate.\n",
+        "Keep replies under 3 paragraphs.\"\"\"\n",
+        "\n",
+        "def process_email(inbox_id: str, message_id: str):\n",
+        "    \"\"\"Process an incoming email and send an AI-generated reply.\"\"\"\n",
+        "    \n",
+        "    # Get the message\n",
+        "    msg = agentmail_client.inboxes.messages.get(\n",
+        "        inbox_id=inbox_id,\n",
+        "        message_id=message_id\n",
+        "    )\n",
+        "    \n",
+        "    # Use extracted_text to get just the new content from the reply\n",
+        "    customer_message = msg.extracted_text or msg.text\n",
+        "    \n",
+        "    # Get thread history for context\n",
+        "    thread = agentmail_client.inboxes.threads.get(\n",
+        "        inbox_id=inbox_id,\n",
+        "        thread_id=msg.thread_id\n",
+        "    )\n",
+        "    \n",
+        "    # Build conversation history for GPT\n",
+        "    conversation = []\n",
+        "    for thread_msg in thread.messages:\n",
+        "        role = \"assistant\" if thread_msg.from_ == inbox_id else \"user\"\n",
+        "        content = thread_msg.extracted_text or thread_msg.text\n",
+        "        conversation.append({\"role\": role, \"content\": content})\n",
+        "    \n",
+        "    # Generate reply with GPT-4\n",
+        "    response = openai_client.chat.completions.create(\n",
+        "        model=\"gpt-4o\",\n",
+        "        messages=[\n",
+        "            {\"role\": \"system\", \"content\": SYSTEM_PROMPT},\n",
+        "            *conversation\n",
+        "        ]\n",
+        "    )\n",
+        "    \n",
+        "    reply_text = response.choices[0].message.content\n",
+        "    \n",
+        "    # Send the reply via AgentMail\n",
+        "    reply = agentmail_client.inboxes.messages.reply(\n",
+        "        inbox_id=inbox_id,\n",
+        "        message_id=message_id,\n",
+        "        text=reply_text\n",
+        "    )\n",
+        "    \n",
+        "    print(f\"Replied to {msg.from_}: {reply_text[:100]}...\")\n",
+        "    return reply"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 5: Process all unread emails\n",
+        "\n",
+        "In production, you'd trigger this via webhooks. Here we'll poll for new messages."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "messages = agentmail_client.inboxes.messages.list(inbox_id=inbox.inbox_id)\n",
+        "\n",
+        "for msg in messages.messages:\n",
+        "    # Skip messages sent by our agent\n",
+        "    if msg.from_ == inbox.inbox_id:\n",
+        "        continue\n",
+        "    \n",
+        "    print(f\"Processing email from {msg.from_}: {msg.subject}\")\n",
+        "    process_email(inbox.inbox_id, msg.message_id)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Using OpenAI Function Calling with AgentMail\n",
+        "\n",
+        "You can also use AgentMail as a tool with OpenAI's function calling. The `agentmail-toolkit` package provides ready-made tool definitions."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!pip install agentmail-toolkit"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from agentmail_toolkit import AgentMailToolkit\n",
+        "\n",
+        "toolkit = AgentMailToolkit(api_key=os.environ[\"AGENTMAIL_API_KEY\"])\n",
+        "\n",
+        "# Get OpenAI-compatible tool definitions\n",
+        "tools = toolkit.get_openai_tools()\n",
+        "\n",
+        "print(f\"Available tools: {[t['function']['name'] for t in tools]}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Let GPT-4 use AgentMail tools autonomously\n",
+        "response = openai_client.chat.completions.create(\n",
+        "    model=\"gpt-4o\",\n",
+        "    messages=[\n",
+        "        {\"role\": \"system\", \"content\": \"You are an AI assistant with email capabilities. Use the email tools to help the user.\"},\n",
+        "        {\"role\": \"user\", \"content\": \"Create a new email inbox and send a welcome email to test@example.com\"}\n",
+        "    ],\n",
+        "    tools=tools\n",
+        ")\n",
+        "\n",
+        "# Process tool calls\n",
+        "for tool_call in response.choices[0].message.tool_calls or []:\n",
+        "    print(f\"Tool: {tool_call.function.name}\")\n",
+        "    print(f\"Args: {tool_call.function.arguments}\")\n",
+        "    \n",
+        "    # Execute the tool\n",
+        "    result = toolkit.execute_tool(tool_call.function.name, tool_call.function.arguments)\n",
+        "    print(f\"Result: {result}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Production Setup: Webhooks\n",
+        "\n",
+        "For production, use webhooks instead of polling. AgentMail sends events to your endpoint in real-time.\n",
+        "\n",
+        "```python\n",
+        "# Create a webhook\n",
+        "webhook = agentmail_client.webhooks.create(\n",
+        "    url=\"https://your-server.com/webhook\",\n",
+        "    events=[\"message.received\"]\n",
+        ")\n",
+        "\n",
+        "# Your webhook handler (Flask example)\n",
+        "from flask import Flask, request\n",
+        "\n",
+        "app = Flask(__name__)\n",
+        "\n",
+        "@app.route('/webhook', methods=['POST'])\n",
+        "def handle_webhook():\n",
+        "    event = request.json\n",
+        "    if event['type'] == 'message.received':\n",
+        "        process_email(\n",
+        "            inbox_id=event['data']['inbox_id'],\n",
+        "            message_id=event['data']['message_id']\n",
+        "        )\n",
+        "    return '', 200\n",
+        "```\n",
+        "\n",
+        "## Next Steps\n",
+        "\n",
+        "- **Custom domains:** Use `agentmail_client.domains.create()` to send from your own domain\n",
+        "- **Attachments:** Send and receive files with messages\n",
+        "- **Semantic search:** Search across inboxes using natural language\n",
+        "- **WebSockets:** Real-time events without a public endpoint\n",
+        "- **Pods:** Isolate email environments per customer\n",
+        "\n",
+        "Learn more at [docs.agentmail.to](https://docs.agentmail.to)"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2470](https://github.com/openai/openai-cookbook/pull/2470)
> **Original author:** @adi-singh13
> **Originally opened:** 2026-02-27

---

## Summary

Adds a new example notebook showing how to build an AI email agent using OpenAI GPT-4 and [AgentMail](https://agentmail.to) — the email API for AI agents.

## What this covers

- Creating programmatic email inboxes for agents
- Sending emails from an agent
- Receiving and processing incoming emails
- Using GPT-4 to generate contextual email replies
- Thread management for multi-turn email conversations
- Using AgentMail's extracted_text for clean reply parsing
- OpenAI function calling with agentmail-toolkit
- Production webhook setup

## Why this is useful

Email is one of the most common capabilities AI agents need — for customer support, authentication (2FA), sales outreach, and document processing. This example shows a clean pattern for building email-powered agents with OpenAI.

## About AgentMail

- YC S25 backed
- API-first email infrastructure for AI agents
- SOC 2 Type II certified
- Free tier available at console.agentmail.to