### PR TITLE
Fix: Remove trailing space in invoice directory  resolves Windows clone failure

### DIFF
--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/20190119_002_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/20190119_002_extracted.json
@@ -1,0 +1,113 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "THE MADISON. HAMBURG",
+            "Address": "MADISON Hotel GmbH, Schaarsteinweg 4, 20459 Hamburg",
+            "Contact": {
+                "Phone": "+49-40-37 666-0",
+                "Fax": "+49-40-37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Mariles Head, Thomas Kleinertz",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "BLZ": "200 300 00",
+                "Konto-Nr": "360 27 11",
+                "IBAN": "DE48 2003 0000 0036 6027 11",
+                "BIC": "HYVEDEMM300"
+            },
+            "AG": "Hamburg HRB 47881",
+            "VAT": "DE118 966 407"
+        },
+        "Guest Information": {
+            "Name": "Herr Jens Walter",
+            "Company": "APImeisler Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin"
+        },
+        "Invoice Information": {
+            "Rechnungs-Nr": "487155 /",
+            "Date": "18.01.19",
+            "Zimmer": "417",
+            "Anreise": "13.01.19",
+            "Abreise": "18.01.19",
+            "Seite": "1 of 1",
+            "Benutzer ID": "RIL"
+        },
+        "Charges": [
+            {
+                "Datum": "13.01.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "14.01.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "15.01.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "16.01.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "17.01.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "18.01.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": null,
+                "Entlastung": 550.0
+            }
+        ],
+        "Summary": {
+            "Total Netto MwSt.": {
+                "Netto EUR": 514.02,
+                "MwSt. EUR": 35.98,
+                "Brutto EUR": 550.0
+            },
+            "Total": {
+                "Belastung": 550.0,
+                "Entlastung": 550.0
+            },
+            "Saldo": "0.00 EUR"
+        },
+        "Finanzamt": {
+            "Name": "Hamburg Mitte",
+            "Steuernummer": "487/410/12828"
+        },
+        "Kreditkarten Details": {
+            "Vertragsnummer": "154084832",
+            "Beleg Nr.": "21891",
+            "Kreditkartennummer": "XXXXXXXXXXXX5052",
+            "Transaktionsbetrag": "550.00",
+            "Verfallsdatum": "XX/XX",
+            "Genehmigter Betrag": "550.00",
+            "Terminal ID": "69284692",
+            "Genehmigungscode": "957699"
+        }
+    },
+    {
+        "hotel_information": {
+            "name": "THE MADISON",
+            "location": "HAMBURG"
+        },
+        "guest_information": null,
+        "invoice_information": null,
+        "room_charges": null,
+        "taxes": null,
+        "total_charges": null
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/20190202_THE MADISON HAMBURG_001_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/20190202_THE MADISON HAMBURG_001_extracted.json
@@ -1,0 +1,112 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "THE MADISON. HAMBURG",
+            "Address": "MADISON Hotel GmbH Schaarsteinweg 4 20459 Hamburg",
+            "Contact": {
+                "Phone": "+49 40.37 666-0",
+                "Fax": "+49 40.37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Marlies Head, Thomas Kleinertz",
+            "Handelsregister": "AG Hamburg HRB 47881",
+            "VAT": "DE118 696 407",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "BLZ": "200 300 00",
+                "Konto-Nr": "360 27 11",
+                "IBAN": "DE48 2003 0000 0036 6027 11",
+                "BIC": "HYVEDEMM300"
+            }
+        },
+        "Guest Information": {
+            "Name": "Herr Jens Walter",
+            "Company": "APimeister Consulting GmbH",
+            "Address": "Friedrichstr. 123 10117 Berlin"
+        },
+        "Invoice Information": {
+            "Rechnungs-Nr": "488615",
+            "Datum": "01.02.19",
+            "Zimmer": "316",
+            "Anreise": "27.01.19",
+            "Abreise": "01.02.19",
+            "Seite": "1 of 1",
+            "Benutzer ID": "RIL"
+        },
+        "Charges": [
+            {
+                "Datum": "27.01.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "28.01.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "29.01.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "30.01.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "31.01.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "01.02.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": 550.0,
+                "Entlastung": null
+            }
+        ],
+        "Summary": {
+            "Umsatzsteuer Detail": {
+                "Netto EUR": 514.02,
+                "MwSt EUR": 35.98,
+                "Brutto EUR": 550.0
+            },
+            "Total inkl. MwSt": {
+                "Total": 550.0,
+                "Saldo": 0.0
+            }
+        },
+        "Payment Information": {
+            "Finanzamt": "Hamburg Mitte",
+            "Steuernummer": "47/841/10122",
+            "Kreditkarteninstitut": {
+                "Vertragsnummer": "154894832",
+                "Kreditkartennummer": "XXXX XXXX XXXX 5052",
+                "Verfallsdatum": "XX/XX",
+                "Terminal ID": "69285492"
+            },
+            "Beleg Nr": "22445",
+            "Transaktionscode": "XXXX",
+            "Genehmigter Betrag": 550.0,
+            "Genehmigungscode": "145348"
+        }
+    },
+    {
+        "hotel_information": {
+            "name": "THE MADISON",
+            "location": "HAMBURG"
+        },
+        "guest_information": null,
+        "invoice_information": null,
+        "room_charges": null,
+        "taxes": null,
+        "total_charges": null
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/20190202_THE MADISON HAMBURG_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/20190202_THE MADISON HAMBURG_extracted.json
@@ -1,0 +1,111 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "THE MADISON. HAMBURG",
+            "Address": "MADISON Hotel GmbH Schaarsteinweg 4 20459 Hamburg",
+            "Contact": {
+                "Phone": "+49.40.37 666-0",
+                "Fax": "+49.40.37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Marlies Head, Thomas Kleinertz",
+            "AG Hamburg HRB": "47881",
+            "VAT": "DE118 686 407",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "BLZ": "200 300 00",
+                "Konto-Nr.": "360 27 11",
+                "IBAN": "DE48 2003 0000 0036 0271 11",
+                "BIC": "HYVEDEMM300"
+            }
+        },
+        "Guest Information": {
+            "Company": "APImeiseter Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin",
+            "Guest Name": "Herr Jens Walter"
+        },
+        "Invoice Information": {
+            "Invoice Number": "487812 /",
+            "Date": "25.01.19",
+            "Room Number": "316",
+            "Arrival Date": "20.01.19",
+            "Departure Date": "25.01.19",
+            "Page": "1 of 1",
+            "User ID": "POE"
+        },
+        "Charges": [
+            {
+                "Datum": "20.01.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "21.01.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "22.01.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "23.01.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "24.01.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "25.01.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": null,
+                "Entlastung": "550.00"
+            }
+        ],
+        "Summary": {
+            "Umsatzsteuer Detail": {
+                "Netto EUR": "514.02",
+                "MwSt. EUR": "35.98",
+                "Brutto EUR": "550.00"
+            },
+            "Total": {
+                "Belastung": "550.00",
+                "Entlastung": "550.00"
+            },
+            "Saldo": "0.00 EUR"
+        },
+        "Payment Information": {
+            "Finanzamt": "Hamburg Mitte",
+            "Steuernummer": "487/410/1228",
+            "Kreditkartendetails": {
+                "Kartennummer": "154984832",
+                "Verfallsdatum": "XX/XX",
+                "Terminal ID": "92954892",
+                "Beleg Nr.": "22161",
+                "Transaktionsbeleg": "550.00",
+                "Genehmigungsnummer": "149460"
+            }
+        }
+    },
+    {
+        "hotel_information": {
+            "name": "THE MADISON",
+            "location": "HAMBURG"
+        },
+        "guest_information": null,
+        "invoice_information": null,
+        "room_charges": null,
+        "taxes": null,
+        "total_charges": null
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/citadines-20190331_Invoice_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/citadines-20190331_Invoice_extracted.json
@@ -1,0 +1,96 @@
+[
+    {
+        "Rechnungsadresse": {
+            "Firma": "APImeisster Consulting GmbH",
+            "Adresse": "Friedrichstrasse 123",
+            "Stadt": "10117 Berlin",
+            "Land": "Germany"
+        },
+        "Gastname": "Herr Jens Walter",
+        "Reservierungsnr.": "1221737070-1",
+        "Apartment Nr.": "420",
+        "Apartment Typ": "1-Bedroom",
+        "Anreisedatum": "31/03/2019",
+        "Abreisedatum": "05/04/2019",
+        "Rechnungsnr.": "083-72561",
+        "A/R Nr.": null,
+        "TO Reference No.": null,
+        "Rechnungsdatum": "05/04/19 - 09:46",
+        "Bediener": "DE-GB",
+        "Seite": "1 von 1",
+        "Tabelle": [
+            {
+                "DATUM": "31/03/19",
+                "APT NR.": "420",
+                "BESCHREIBUNG": "Apartment 31/03/19#420",
+                "EURO": "92,56"
+            },
+            {
+                "DATUM": "01/04/19",
+                "APT NR.": "420",
+                "BESCHREIBUNG": "Apartment 01/04/19#420",
+                "EURO": "197,20"
+            },
+            {
+                "DATUM": "02/04/19",
+                "APT NR.": "420",
+                "BESCHREIBUNG": "Apartment 02/04/19#420",
+                "EURO": "254,15"
+            },
+            {
+                "DATUM": "03/04/19",
+                "APT NR.": "420",
+                "BESCHREIBUNG": "Apartment 03/04/19#420",
+                "EURO": "215,90"
+            },
+            {
+                "DATUM": "04/04/19",
+                "APT NR.": "420",
+                "BESCHREIBUNG": "Apartment 04/04/19#420",
+                "EURO": "143,82"
+            },
+            {
+                "DATUM": "31/03/19",
+                "APT NR.": "420",
+                "BESCHREIBUNG": "Mastercard bnr 8324 SPLIT",
+                "EURO": "-903,63"
+            }
+        ],
+        "Summe Belastungen": "903,63",
+        "Summe Zahlungen": "-903,63",
+        "offener Betrag": "0,00",
+        "MwSt.": [
+            {
+                "Satz": "19.00 %",
+                "NETTO €": "0,00",
+                "MwSt €": "0,00",
+                "BRUTTO €": "0,00"
+            },
+            {
+                "Satz": "7.00 %",
+                "NETTO €": "844,51",
+                "MwSt €": "59,12",
+                "BRUTTO €": "903,63"
+            },
+            {
+                "Satz": "0.00 %",
+                "NETTO €": "0,00",
+                "MwSt €": "0,00",
+                "BRUTTO €": "0,00"
+            }
+        ],
+        "Hotel Information": {
+            "Name": "Citadines Michel Hamburg",
+            "Adresse": "Ludwig-Erhard-Str. 7, D-20459 Hamburg, Deutschland",
+            "Telefon": "+49 (0)40-30618-0",
+            "Fax": "+49 (0)40-30618-1999",
+            "Email": "hamburg@citadines.com",
+            "Website": "www.citadines.com",
+            "Betreiber": "Citadines Betriebes GmbH - Amtsgericht Frankfurt/Main - HRB 52815",
+            "Bankverbindung": "Commerzbank Frankfurt - St.-Nr.: 040 230 34731",
+            "IBAN": "DE27500400000385712500",
+            "Swift/BIC": "COBADEFFXXX"
+        }
+    },
+    {}
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/citadines_08372561_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/citadines_08372561_extracted.json
@@ -1,0 +1,105 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "Citadines Michel Hamburg",
+            "Address": "Ludwig-Erhard-Str. 7, D-20459 Hamburg, Deutschland",
+            "Contact": {
+                "Phone": "+49 (0)40-300618-0",
+                "Fax": "+49 (0)40-300618-1999",
+                "Email": "hamburg@citadines.com",
+                "Website": "www.citadines.com"
+            },
+            "Operator": "Citadines Betreibs GmbH - Amtsgericht Frankfurt/Main - HRB 52815",
+            "Bank Information": {
+                "Bank": "Commerzbank Frankfurt",
+                "Account Number": "040 230 3437",
+                "IBAN": "DE27500400000385712500",
+                "Swift/BIC": "COBADEFFXXX"
+            }
+        },
+        "Rechnungsadresse": {
+            "Company": "APImeisler Consulting GmbH",
+            "Address": "Friedrichstrasse 123, 10117 Berlin, Germany"
+        },
+        "Guest Information": {
+            "Name": "Herr Jens Walter",
+            "Reservierungsnr": "1221737070-1",
+            "Apartment Nr": "420",
+            "Apartment Typ": "1-Bedroom",
+            "Anreisedatum": "31/03/2019",
+            "Abreisedatum": "05/04/2019"
+        },
+        "Invoice Information": {
+            "Rechnungsnr": "083-72561",
+            "A/R Nr": null,
+            "TO Reference No": null,
+            "Rechnungsdatum": "05/04/19 - 09:46",
+            "Bediener": "DE-GB",
+            "Seite": "1 von 1"
+        },
+        "Charges": [
+            {
+                "DATUM": "31/03/19",
+                "APT NR": "420",
+                "BESCHREIBUNG": "Apartment 31/03/19#420",
+                "EURO": "92,56"
+            },
+            {
+                "DATUM": "01/04/19",
+                "APT NR": "420",
+                "BESCHREIBUNG": "Apartment 01/04/19#420",
+                "EURO": "197,20"
+            },
+            {
+                "DATUM": "02/04/19",
+                "APT NR": "420",
+                "BESCHREIBUNG": "Apartment 02/04/19#420",
+                "EURO": "254,15"
+            },
+            {
+                "DATUM": "03/04/19",
+                "APT NR": "420",
+                "BESCHREIBUNG": "Apartment 03/04/19#420",
+                "EURO": "215,90"
+            },
+            {
+                "DATUM": "04/04/19",
+                "APT NR": "420",
+                "BESCHREIBUNG": "Apartment 04/04/19#420",
+                "EURO": "143,82"
+            },
+            {
+                "DATUM": "31/03/19",
+                "APT NR": "420",
+                "BESCHREIBUNG": "Mastercard bnr 8324 SPLIT",
+                "EURO": "-903,63"
+            }
+        ],
+        "Summary": {
+            "Summe Belastungen": "903,63",
+            "Summe Zahlungen": "-903,63",
+            "offener Betrag": "0,00"
+        },
+        "Taxes": [
+            {
+                "MwSt. %": "19.00 %",
+                "NETTO €": "0,00",
+                "MwSt €": "0,00",
+                "BRUTTO €": "0,00"
+            },
+            {
+                "MwSt. %": "7.00 %",
+                "NETTO €": "844,51",
+                "MwSt €": "59,12",
+                "BRUTTO €": "903,63"
+            },
+            {
+                "MwSt. %": "0.00 %",
+                "NETTO €": "0,00",
+                "MwSt €": "0,00",
+                "BRUTTO €": "0,00"
+            }
+        ]
+    },
+    {}
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/hampton-25789_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/hampton-25789_extracted.json
@@ -1,0 +1,216 @@
+[
+    {
+        "hotel_information": {
+            "name": "Hampton by Hilton Hamburg City Centre",
+            "address": "Nordkanalstrasse 18, 20097 Hamburg",
+            "phone": "+49(0)40-302372-0",
+            "fax": "+49(0)40-302372-100"
+        },
+        "guest_information": {
+            "name": "APIMEISTER CONSULTING GMBH",
+            "address": "FRIEDRICHSTR. 123, 10117 BERLIN, GERMANY",
+            "guest_name": "JENS WALTER"
+        },
+        "invoice_information": {
+            "VAT_invoice_number": "25789",
+            "confirmation_number": "5296853",
+            "VAT": "DE289859636",
+            "folio_number": "111090A"
+        },
+        "stay_information": {
+            "room_number": "511 /NUX",
+            "arrival_date": "02/06/2019 02:00:00",
+            "departure_date": "07/06/2019",
+            "adults_children": "1/0",
+            "room_rate": "156.56",
+            "rate_plan": "2D2"
+        },
+        "charges": [
+            {
+                "date": "03/06/2019",
+                "description": "CREDIT CARD - ADVANCE DEPOSIT *5052",
+                "cashier_id": "ANPE",
+                "ref_no": "351221",
+                "guest_charges": null,
+                "credit": "€776.56",
+                "balance": null
+            },
+            {
+                "date": "03/06/2019",
+                "description": "CANCELLATION CHARGE",
+                "cashier_id": "ANPE",
+                "ref_no": "351222",
+                "guest_charges": "€155.00",
+                "credit": null,
+                "balance": null
+            },
+            {
+                "date": "03/06/2019",
+                "description": "CANCELLATION CHARGE",
+                "cashier_id": "ERLO",
+                "ref_no": "351229",
+                "guest_charges": null,
+                "credit": "€155.00",
+                "balance": null
+            },
+            {
+                "date": "03/06/2019",
+                "description": "GUEST ROOM",
+                "cashier_id": "ERLO",
+                "ref_no": "351277",
+                "guest_charges": "€150.05",
+                "credit": null,
+                "balance": null
+            },
+            {
+                "date": "03/06/2019",
+                "description": "BREAKFAST",
+                "cashier_id": "ERLO",
+                "ref_no": "351297",
+                "guest_charges": "€9.45",
+                "credit": null,
+                "balance": null
+            },
+            {
+                "date": "04/06/2019",
+                "description": "GUEST ROOM",
+                "cashier_id": "JONER",
+                "ref_no": "352209",
+                "guest_charges": "€150.05",
+                "credit": null,
+                "balance": null
+            },
+            {
+                "date": "04/06/2019",
+                "description": "BREAKFAST",
+                "cashier_id": "JONER",
+                "ref_no": "352276",
+                "guest_charges": "€9.45",
+                "credit": null,
+                "balance": null
+            },
+            {
+                "date": "05/06/2019",
+                "description": "GUEST ROOM",
+                "cashier_id": "ERLO",
+                "ref_no": "352767",
+                "guest_charges": "€150.05",
+                "credit": null,
+                "balance": null
+            },
+            {
+                "date": "05/06/2019",
+                "description": "BREAKFAST",
+                "cashier_id": "ERLO",
+                "ref_no": "352769",
+                "guest_charges": "€9.45",
+                "credit": null,
+                "balance": null
+            },
+            {
+                "date": "06/06/2019",
+                "description": "GUEST ROOM",
+                "cashier_id": "JONER",
+                "ref_no": "353331",
+                "guest_charges": "€161.61",
+                "credit": null,
+                "balance": null
+            },
+            {
+                "date": "06/06/2019",
+                "description": "BREAKFAST",
+                "cashier_id": "JONER",
+                "ref_no": "353331",
+                "guest_charges": "€9.45",
+                "credit": null,
+                "balance": null
+            },
+            {
+                "date": "07/06/2019",
+                "description": "GUEST ROOM",
+                "cashier_id": "ANPE",
+                "ref_no": "353477",
+                "guest_charges": "€150.05",
+                "credit": null,
+                "balance": null
+            }
+        ]
+    },
+    {
+        "hotel_information": {
+            "name": "Hampton by Hilton Hamburg City Centre",
+            "address": "Nordkanalstraße 18, 20097 Hamburg",
+            "contact": {
+                "phone": "+49(0)40-302372-0",
+                "fax": "+49(0)40-302372-100"
+            }
+        },
+        "guest_information": {
+            "company": "APIMEISTER CONSULTING GMBH",
+            "address": {
+                "street": "FRIEDRICHSTR. 123",
+                "city": "BERLIN",
+                "postal_code": "10117",
+                "country": "GERMANY"
+            },
+            "name": "JENS WALTER"
+        },
+        "invoice_information": {
+            "invoice_number": "25789",
+            "confirmation_number": "52966853",
+            "vat_number": "DE259895536",
+            "folio_number": "111903 A"
+        },
+        "stay_information": {
+            "room_number": "511 /NUX",
+            "arrival_date": "02/06/2019 02:00:00",
+            "departure_date": "07/06/2019",
+            "adults_children": "1/0",
+            "room_rate": "156.56",
+            "rate_plan": "202",
+            "al": "null",
+            "h": "null",
+            "i": "null"
+        },
+        "charges": [
+            {
+                "date": "07/06/2019",
+                "description": "BREAKFAST",
+                "cashier_id": "ANPE",
+                "ref_no": "353477",
+                "guest_charges": "€4.95",
+                "credit": "null",
+                "balance": "€60.00"
+            }
+        ],
+        "tax_summary": {
+            "trade_receivable_net_19%": "€20.80",
+            "trade_receivable_net_7%": "€0.00",
+            "trade_receivable_net_7.00%": "€702.61",
+            "vat_1%": "€3.95",
+            "fsb_vat_7%": "€0.00",
+            "vat_at_7%": "€49.20",
+            "trade_receivables_incl_vat": "€776.56"
+        },
+        "approval_amount": {
+            "transaction_id": "\"BALANCE\"",
+            "appr_code": "-€776.56"
+        },
+        "signature": {
+            "guest_signature": "null",
+            "debit_related_verbiage": "null"
+        },
+        "footer": {
+            "company": "Foremost Hospitality Management GmbH",
+            "address": "Str. Berlin | Joachimsthaler Str. 34, 10719 Berlin",
+            "registration": "Amtsgericht Charlottenburg, Berlin HRB 112538 B",
+            "vat_number": "DE259895536",
+            "managing_directors": "Hubert van de Loo, Timo Künner",
+            "bank_details": {
+                "bank": "Commerzbank",
+                "iban": "DE19 1004 0002 0230 7036 08",
+                "bic_swift": "COBADEFFXXX"
+            }
+        }
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/hampton_20190411_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/hampton_20190411_extracted.json
@@ -1,0 +1,158 @@
+[
+    {
+        "hotel_information": {
+            "name": "Hampton by Hilton Hamburg City Centre",
+            "address": "Nordkanalstrasse 18, 20097 Hamburg",
+            "phone": "+49(0)40-302372-0",
+            "fax": "+49(0)40-302372-100"
+        },
+        "guest_information": {
+            "name": "APIMEISTER CONSULTING GMBH",
+            "address": "FRIEDRICHSTR. 123, 10117 BERLIN, GERMANY",
+            "guest_name": "JENS WALTER"
+        },
+        "invoice_information": {
+            "invoice_number": "31611",
+            "confirmation_number": "92353607",
+            "VAT": "DE258969536",
+            "folio_no": "126069 A"
+        },
+        "stay_information": {
+            "room_no": "216",
+            "arrival_date": "04/11/2019 19:00:00",
+            "departure_date": "08/11/2019",
+            "adults/children": "1/0",
+            "room_rate": "99.00",
+            "rate_plan": "2G2",
+            "HH #": "null"
+        },
+        "charges": [
+            {
+                "date": "04/11/2019",
+                "description": "MC *5620",
+                "cashier_id": "ANPE",
+                "ref_no": "437200",
+                "guest_charges": "-476.00",
+                "credit": "null",
+                "balance": "null"
+            },
+            {
+                "date": "04/11/2019",
+                "description": "GUEST ROOM",
+                "cashier_id": "MACH",
+                "ref_no": "437361",
+                "guest_charges": "null",
+                "credit": "€94.05",
+                "balance": "null"
+            },
+            {
+                "date": "05/11/2019",
+                "description": "BREAKFAST",
+                "cashier_id": "MACH",
+                "ref_no": "437361",
+                "guest_charges": "null",
+                "credit": "€4.95",
+                "balance": "null"
+            },
+            {
+                "date": "05/11/2019",
+                "description": "GUEST ROOM",
+                "cashier_id": "MACH",
+                "ref_no": "437770",
+                "guest_charges": "null",
+                "credit": "€134.05",
+                "balance": "null"
+            },
+            {
+                "date": "05/11/2019",
+                "description": "BREAKFAST",
+                "cashier_id": "MACH",
+                "ref_no": "437770",
+                "guest_charges": "null",
+                "credit": "€4.95",
+                "balance": "null"
+            },
+            {
+                "date": "06/11/2019",
+                "description": "GUEST ROOM",
+                "cashier_id": "ANPE",
+                "ref_no": "438200",
+                "guest_charges": "null",
+                "credit": "€114.05",
+                "balance": "null"
+            },
+            {
+                "date": "06/11/2019",
+                "description": "BREAKFAST",
+                "cashier_id": "ANPE",
+                "ref_no": "438200",
+                "guest_charges": "null",
+                "credit": "€4.95",
+                "balance": "null"
+            },
+            {
+                "date": "07/11/2019",
+                "description": "GUEST ROOM",
+                "cashier_id": "MACH",
+                "ref_no": "438616",
+                "guest_charges": "null",
+                "credit": "€114.05",
+                "balance": "null"
+            }
+        ]
+    },
+    {
+        "hotel_information": {
+            "name": "Hampton by Hilton Hamburg City Centre",
+            "address": "Nordkanalstrasse 18, 20097 Hamburg",
+            "phone": "+49(0)40-302372-0",
+            "fax": "+49(0)40-302372-100"
+        },
+        "guest_information": {
+            "name": "APIMEISTER CONSULTING GMBH",
+            "address": "FRIEDRICHSTR. 123, 10117 BERLIN, GERMANY",
+            "guest_name": "JENS WALTER"
+        },
+        "invoice_information": {
+            "invoice_number": "31611",
+            "confirmation_number": "92353607",
+            "VAT_number": "DE259985536",
+            "folio_number": "126609 A"
+        },
+        "stay_information": {
+            "room_number": "216",
+            "arrival_date": "04/11/2019 19:09:00",
+            "departure_date": "08/11/2019",
+            "adults_children": "1/0",
+            "rate_plan": "2G2"
+        },
+        "charges": [
+            {
+                "date": "07/11/2019",
+                "description": "BREAKFAST",
+                "cashier_id": "MACH",
+                "ref_no": "438616",
+                "guest_charges": "€4.95",
+                "credit": null,
+                "balance": "€0.00"
+            }
+        ],
+        "tax_summary": {
+            "trade_receivable_net_19%": "€16.64",
+            "trade_receivable_net_7%": "€0.00",
+            "trade_receivable_net_7.00%": "€426.36",
+            "VAT_19%": "€3.16",
+            "F&B_VAT_7%": "€0.00",
+            "VAT_7%": "€29.84",
+            "trade_receivables_incl_VAT": "€476.00"
+        },
+        "payment_information": {
+            "approval_amount": "€476.00",
+            "approval_code": "109423",
+            "transaction_id": "437200",
+            "balance": "-€476.00"
+        },
+        "signature": "Guest Signature",
+        "note": "Debit related verbiage"
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/hampton_24361_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/hampton_24361_extracted.json
@@ -1,0 +1,148 @@
+[
+    {
+        "hotel_information": {
+            "name": "Hampton by Hilton Hamburg City Centre",
+            "address": "Nordkanalstrasse 18, 20097 Hamburg",
+            "phone": "+49(0)40-302372-0",
+            "fax": "+49(0)40-302372-100"
+        },
+        "guest_information": {
+            "name": "JENS WALTER",
+            "company": "APIMEISTER CONSULTING GMBH",
+            "address": "FRIEDRICHSR. 123, 10117 BERLIN, GERMANY"
+        },
+        "invoice_information": {
+            "vat_invoice": "24361",
+            "confirmation_number": "87607957",
+            "arrival_date": "28/04/2019 23:53:00",
+            "departure_date": "30/04/2019",
+            "room_no": "119",
+            "adult/child": "1/0",
+            "room_rate": "102.00",
+            "rate_plan": "2G2",
+            "vat": "DE259895636",
+            "folio_no/che": "107155A"
+        },
+        "charges": [
+            {
+                "date": "28/04/2019",
+                "description": "Advance Deposit MC *2828",
+                "cashier_id": "GARO",
+                "ref_no": "331422",
+                "guest_charges": null,
+                "credit": "€221.00",
+                "balance": "-€221.00"
+            },
+            {
+                "date": "28/04/2019",
+                "description": "ADVANCED DEPOSIT DEBIT",
+                "cashier_id": "GARO",
+                "ref_no": "331424",
+                "guest_charges": "€221.00",
+                "credit": null,
+                "balance": "€0.00"
+            },
+            {
+                "date": "28/04/2019",
+                "description": "ADVANCED DEPOSIT CREDIT",
+                "cashier_id": "GARO",
+                "ref_no": "331425",
+                "guest_charges": null,
+                "credit": "€221.00",
+                "balance": "€221.00"
+            },
+            {
+                "date": "28/04/2019",
+                "description": "GUEST ROOM",
+                "cashier_id": "GARO",
+                "ref_no": "331455",
+                "guest_charges": "€97.05",
+                "credit": null,
+                "balance": "€318.05"
+            },
+            {
+                "date": "28/04/2019",
+                "description": "BREAKFAST",
+                "cashier_id": "GARO",
+                "ref_no": "331455",
+                "guest_charges": "€14.95",
+                "credit": null,
+                "balance": "€333.00"
+            },
+            {
+                "date": "29/04/2019",
+                "description": "GUEST ROOM",
+                "cashier_id": "FEBA",
+                "ref_no": "331959",
+                "guest_charges": "€114.05",
+                "credit": null,
+                "balance": "€447.05"
+            }
+        ]
+    },
+    {
+        "hotel_information": {
+            "name": "Hampton by Hilton Hamburg City Centre",
+            "address": "Nordkanalstraße 18, 20097 Hamburg",
+            "contact": {
+                "phone": "+49(0)40-302372-0",
+                "fax": "+49(0)40-302372-100"
+            }
+        },
+        "guest_information": {
+            "name": "APIMEISTER CONSULTING GMBH",
+            "address": {
+                "street": "FRIEDRICHSTR. 123",
+                "city": "BERLIN",
+                "postal_code": "10117",
+                "country": "GERMANY"
+            },
+            "guest_name": "JENS WALTER"
+        },
+        "invoice_information": {
+            "invoice_number": "24361",
+            "confirmation_number": "87607597",
+            "vat_number": "DE259965636",
+            "folio_number": "107515 A"
+        },
+        "stay_information": {
+            "room_number": "119",
+            "arrival_date": "28/04/2019 23:53:00",
+            "departure_date": "30/04/2019",
+            "adults_children": "1/0",
+            "room_rate": "102.00",
+            "rate_plan": "2G2",
+            "cashier_id": "FEBA",
+            "ref_no": "331969",
+            "hhonors_number": "107515 A"
+        },
+        "charges": [
+            {
+                "date": "29/04/2019",
+                "description": "BREAKFAST",
+                "guest_charges": "64.95",
+                "credit": null,
+                "balance": "€0.00"
+            }
+        ],
+        "tax_summary": {
+            "trade_receivable_net_19%": "€8.32",
+            "trade_receivable_net_7%": "€0.00",
+            "trade_receivable_net_7.00%": "€197.29",
+            "vat_at_19%": "€1.58",
+            "f&b_vat_7%": "€0.00",
+            "vat_at_7%": "€13.81",
+            "trade_receivables_incl_vat": "€221.00"
+        },
+        "payment_information": {
+            "approval_amount": "€221.00",
+            "approval_code": "491464",
+            "transaction_id": "331422",
+            "balance": "€221.00"
+        },
+        "signature": {
+            "guest_signature": null,
+            "debit_related_verbiage": null
+        }
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/hampton_28646_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/hampton_28646_extracted.json
@@ -1,0 +1,179 @@
+[
+    {
+        "hotel_information": {
+            "name": "Hampton by Hilton Hamburg City Centre",
+            "address": "Nordkanalstrasse 18, 20097 Hamburg",
+            "contact": {
+                "phone": "+49(0)40-302372-0",
+                "fax": "+49(0)40-302372-100"
+            }
+        },
+        "guest_information": {
+            "company": "APIMEISTER CONSULTING GMBH",
+            "address": "FRIEDRICHSTR 123, 10117 BERLIN, GERMANY",
+            "guest_name": "JENS WALTER"
+        },
+        "invoice_information": {
+            "vat_invoice": "26846",
+            "confirmation_number": "81134041",
+            "invoice_date": "23/08/2019 09:20:00",
+            "vat_number": "DE259895636",
+            "folio_number": "119062 A"
+        },
+        "stay_information": {
+            "room_number": "707 /NUDX",
+            "arrival_date": "19/08/2019 17:55:00",
+            "departure_date": "23/08/2019",
+            "adults_children": "1/0",
+            "room_rate": "129.00",
+            "rate_plan": "2GQ"
+        },
+        "charges": [
+            {
+                "date": "19/08/2019",
+                "description": "Advance Deposit MC *5052",
+                "cashier_id": "TARO",
+                "ref_no": "396235",
+                "guest_charges": null,
+                "credit": "-€516.00",
+                "balance": "-€516.00"
+            },
+            {
+                "date": "19/08/2019",
+                "description": "ADVANCED DEPOSIT DEBIT",
+                "cashier_id": "TARO",
+                "ref_no": "396235",
+                "guest_charges": "€516.00",
+                "credit": null,
+                "balance": "0.00"
+            },
+            {
+                "date": "19/08/2019",
+                "description": "ADVANCED DEPOSIT CREDIT",
+                "cashier_id": "TARO",
+                "ref_no": "396237",
+                "guest_charges": null,
+                "credit": "-€516.00",
+                "balance": "-€516.00"
+            },
+            {
+                "date": "19/08/2019",
+                "description": "GUEST ROOM",
+                "cashier_id": "MACH",
+                "ref_no": "396605",
+                "guest_charges": "€124.05",
+                "credit": null,
+                "balance": "-€391.95"
+            },
+            {
+                "date": "19/08/2019",
+                "description": "BREAKFAST",
+                "cashier_id": "MACH",
+                "ref_no": "396655",
+                "guest_charges": "€4.95",
+                "credit": null,
+                "balance": "-€387.00"
+            },
+            {
+                "date": "20/08/2019",
+                "description": "GUEST ROOM",
+                "cashier_id": "MACH",
+                "ref_no": "396777",
+                "guest_charges": "€134.05",
+                "credit": null,
+                "balance": "-€252.95"
+            },
+            {
+                "date": "20/08/2019",
+                "description": "BREAKFAST",
+                "cashier_id": "MACH",
+                "ref_no": "396877",
+                "guest_charges": "€4.95",
+                "credit": null,
+                "balance": "-€248.00"
+            },
+            {
+                "date": "21/08/2019",
+                "description": "GUEST ROOM",
+                "cashier_id": "MACH",
+                "ref_no": "397412",
+                "guest_charges": "€124.05",
+                "credit": null,
+                "balance": "-€123.95"
+            },
+            {
+                "date": "21/08/2019",
+                "description": "BREAKFAST",
+                "cashier_id": "MACH",
+                "ref_no": "397412",
+                "guest_charges": "€4.95",
+                "credit": null,
+                "balance": "-€119.00"
+            },
+            {
+                "date": "22/08/2019",
+                "description": "GUEST ROOM",
+                "cashier_id": "MACH",
+                "ref_no": "397699",
+                "guest_charges": "€114.05",
+                "credit": null,
+                "balance": "-€4.95"
+            }
+        ]
+    },
+    {
+        "hotel_information": {
+            "name": "Hampton by Hilton Hamburg City Centre",
+            "address": "Nordkanalstrasse 18, 20097 Hamburg",
+            "phone": "+49(0)40-302372-0",
+            "fax": "+49(0)40-302372-100"
+        },
+        "guest_information": {
+            "company": "APMEISTER CONSULTING GMBH",
+            "address": "DREIDRICHSTR 123, 10117 BERLIN, GERMANY",
+            "guest_name": "JENS WALTER"
+        },
+        "invoice_information": {
+            "vat_invoice": "28646",
+            "confirmation_number": "81134041",
+            "vat": "DE259895636",
+            "folio_no": "119562 A"
+        },
+        "stay_information": {
+            "room_no": "707",
+            "arrival_date": "19/08/2019 17:55:00",
+            "departure_date": "23/08/2019",
+            "adult/child": "1/0",
+            "room_rate": "120.00",
+            "rate_plan": "2C2",
+            "al": "H"
+        },
+        "charges": [
+            {
+                "date": "22/08/2019",
+                "description": "BREAKFAST",
+                "cashier_id": "MACH",
+                "ref_no": "3797690",
+                "guest_charges": "4.95",
+                "credit": null,
+                "balance": null
+            }
+        ],
+        "balance": "0.00",
+        "tax_summary": {
+            "trade_receivable_net_19.00%": "€18.64",
+            "trade_receivable_net_7.00%": "€0.00",
+            "trade_receivable_net_7.00%_2": "€443.73",
+            "vat_at_19%": "€3.16",
+            "f&b_vat_7%": "€0.00",
+            "vat_at_7%": "€32.47",
+            "trade_receivables_incl_vat": "€516.00"
+        },
+        "approval_amount": "€516.00",
+        "transaction_id": "390235",
+        "appr_code": "277397",
+        "balance_2": "-€516.00",
+        "guest_signature": "Debit related webpage",
+        "thank_you_note": "THANK YOU FOR STAYING WITH US!"
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-489347_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-489347_extracted.json
@@ -1,0 +1,104 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "THE MADISON. HAMBURG",
+            "Address": "MADISON Hotel GmbH Schaarsteinweg 4 20459 Hamburg",
+            "Contact": {
+                "Phone": "+49-40-37 666-0",
+                "Fax": "+49-40-37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Bank Details": {
+                "Bank": "HypoVereinsbank",
+                "BLZ": "200 300 00",
+                "Konto-Nr": "360 27 11",
+                "IBAN": "DE84 2003 0000 0003 6027 11",
+                "BIC": "HYVEDEMM300"
+            }
+        },
+        "Guest Information": {
+            "Name": "Herr Jens Walter",
+            "Company": "APImeiser Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin"
+        },
+        "Invoice Information": {
+            "Rechnungs-Nr.": "489347 /",
+            "Datum": "08.02.19",
+            "Zimmer": "334",
+            "Anreise": "03.02.19",
+            "Abreise": "08.02.19",
+            "Seite": "1 of 1",
+            "Benutzer ID": "POE"
+        },
+        "Charges": [
+            {
+                "Datum": "03.02.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "04.02.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "05.02.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "06.02.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "07.02.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "08.02.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": null,
+                "Entlastung": 550.0
+            }
+        ],
+        "Summary": {
+            "Umsatzsteuer Detail": {
+                "Netto EUR": 514.02,
+                "MwSt. EUR": 35.98,
+                "Brutto EUR": 550.0
+            },
+            "Total": {
+                "Belastung": 550.0,
+                "Entlastung": 550.0
+            },
+            "Saldo": {
+                "Total": 0.0,
+                "Currency": "EUR"
+            }
+        },
+        "Payment Information": {
+            "Finanzamt": "Hamburg Mitte",
+            "Steuernummer": "487/410/12128",
+            "Kreditkartendetails": {
+                "Kartenaussteller": "15498432",
+                "Kreditkartennummer": "XXXXXXXXXXXX5502",
+                "Verfallsdatum": "XX/XX",
+                "Terminal ID": "6926492",
+                "Beleg Nr.": "22705",
+                "Transaktionsbetrag": "550.00",
+                "Genehmigter Betrag": "550.00",
+                "Genehmigungscode": "67109"
+            },
+            "Unterschrift": "Unterschrift des Karteninhabers"
+        }
+    },
+    {}
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-490057_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-490057_extracted.json
@@ -1,0 +1,107 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "MADISON Hotel GmbH",
+            "Address": "Schaarsteinweg 4, 20459 Hamburg",
+            "Contact": {
+                "Phone": "+49.40.37 66 0",
+                "Fax": "+49.40.37 66 137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Marlies Head, Thomas Kleinertz",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "BLZ": "200 300 00",
+                "Konto-Nr": "360 27 11",
+                "IBAN": "DE40 2003 0000 0036 0271 11",
+                "BIC": "HYVEDEMM300"
+            },
+            "VAT": "DE118 686 407",
+            "AG Hamburg HRB": "47881"
+        },
+        "Guest Information": {
+            "Company": "APImeleister Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin",
+            "Guest Name": "Herr Jens Walter"
+        },
+        "Invoice Information": {
+            "Rechnungs-Nr": "490057 /",
+            "Date": "15.02.19",
+            "Room": "336",
+            "Arrival": "10.02.19",
+            "Departure": "15.02.19",
+            "Page": "1 of 1",
+            "User ID": "SMA"
+        },
+        "Charges": [
+            {
+                "Datum": "10.02.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "11.02.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "12.02.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "13.02.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "14.02.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "15.02.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": 550.0,
+                "Entlastung": null
+            }
+        ],
+        "Summary": {
+            "Umsatzsteuer Detail": {
+                "Netto EUR": 514.02,
+                "MwSt. EUR": 35.98,
+                "Brutto EUR": 550.0
+            },
+            "Total": {
+                "Total incl. MwSt.": 550.0,
+                "Saldo": 0.0
+            }
+        },
+        "Payment Information": {
+            "Finanzamt": "Hamburg Mitte",
+            "Steuernummer": "47/471/01228",
+            "Kreditkartendetails": {
+                "Kartenunternehmen": "Mastercard",
+                "Kreditkartennummer": "154498432",
+                "Verfallsdatum": "XX/XX",
+                "Terminal ID": "69264961",
+                "Beleg Nr.": "6692",
+                "Transaktionsbetrag": 550.0,
+                "Genehmigter Betrag": 550.0,
+                "Genehmigungsnr.": "258692"
+            }
+        }
+    },
+    {
+        "hotel_information": {
+            "name": "THE MADISON",
+            "location": "HAMBURG"
+        }
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-490969_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-490969_extracted.json
@@ -1,0 +1,114 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "MADISON Hotel GmbH",
+            "Address": "Schaarsteinweg 4, 20459 Hamburg",
+            "Contact": {
+                "Phone": "+49.40.37 666-0",
+                "Fax": "+49.40.37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Markies Head, Thomas Kleinertz",
+            "VAT": "DE118 696 407",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "IBAN": "DE48 2003 0000 0030 6027 11",
+                "BIC": "HYVEDEMM300"
+            }
+        },
+        "Guest Information": {
+            "Company": "APImeleister Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin",
+            "Guest Name": "Herr Jens Walter"
+        },
+        "Invoice Information": {
+            "Invoice Number": "490969",
+            "Date": "22.02.19",
+            "Room Number": "320",
+            "Arrival Date": "17.02.19",
+            "Departure Date": "22.02.19",
+            "Page": "1 of 1",
+            "User ID": "JAS"
+        },
+        "Charges": [
+            {
+                "Datum": "17.02.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "18.02.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "19.02.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "20.02.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "21.02.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "22.02.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": null,
+                "Entlastung": 550.0
+            }
+        ],
+        "Summary": {
+            "Umsatzsteuer Detail": {
+                "Netto EUR": 514.02,
+                "MwSt. EUR": 35.98,
+                "Brutto EUR": 550.0
+            },
+            "Total": {
+                "Belastung": 550.0,
+                "Entlastung": 550.0
+            },
+            "Saldo": {
+                "Amount": 0.0,
+                "Currency": "EUR"
+            }
+        },
+        "Payment Information": {
+            "Finanzamt": "Hamburg Mitte",
+            "Steuernummer": "487/410/10228",
+            "Kreditkarteninstitut": "XXXXXX",
+            "Verfallsdatum": "XX/XX",
+            "Terminal ID": "69284962",
+            "Karteninhaber": {
+                "Kartennummer": "XXXX XXXX XXXX 5052",
+                "Vorgangsnummer": "154698432",
+                "Beleg Nr.": "23137",
+                "Transaktionsbetrag": 550.0,
+                "Genehmigter Betrag": 550.0,
+                "Genehmigungscode": "811233"
+            }
+        }
+    },
+    {
+        "hotel_information": {
+            "name": "THE MADISON",
+            "location": "HAMBURG"
+        },
+        "guest_information": null,
+        "invoice_information": null,
+        "room_charges": null,
+        "taxes": null,
+        "total_charges": null
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-492602_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-492602_extracted.json
@@ -1,0 +1,105 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "MADISON Hotel GmbH",
+            "Address": "Schaarsteinweg 4, 20459 Hamburg",
+            "Contact": {
+                "Phone": "+49.40.37 666-0",
+                "Fax": "+49.40.37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Marlies Head, Thomas Kleinertz",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "BLZ": "200 300 00",
+                "Konto-Nr": "360 27 11",
+                "IBAN": "DE48 2003 0000 0003 6027 11",
+                "BIC": "HYVEDEMM300"
+            },
+            "Handelsregister": {
+                "AG Hamburg HRB": "47881",
+                "VAT": "DE118 696 407"
+            }
+        },
+        "Guest Information": {
+            "Company": "APfmeister Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin",
+            "Guest Name": "Herr Jens Walter"
+        },
+        "Invoice Information": {
+            "Rechnungs-Nr": "492602 /",
+            "Date": "08.03.19",
+            "Room": "438",
+            "Arrival": "03.03.19",
+            "Departure": "08.03.19",
+            "Page": "1 of 1",
+            "User ID": "LBE"
+        },
+        "Charges": [
+            {
+                "Datum": "03.03.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "04.03.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "05.03.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "06.03.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "07.03.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "08.03.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": null,
+                "Entlastung": "550.00"
+            }
+        ],
+        "Summary": {
+            "Umsatzsteuer Detail": {
+                "Netto EUR": "514.02",
+                "MwSt EUR": "35.98",
+                "Brutto EUR": "550.00"
+            },
+            "Total": {
+                "Total Belastung": "550.00",
+                "Total Entlastung": "550.00"
+            },
+            "Saldo": "0.00 EUR"
+        },
+        "Payment Information": {
+            "Finanzamt": "Hamburg Mitte",
+            "Steuernummer": "48/741/01122B",
+            "Kreditkartendetails": {
+                "Vertragspartner": "15469432",
+                "Kreditkartennummer": "XXXX XXXX XXXX 5052",
+                "Verfallsdatum": "XX/XX",
+                "Terminal ID": "69264993"
+            },
+            "Betrag Nr": "31630",
+            "Transaktionsbetrag": "550.00",
+            "Genehmigter Betrag": "550.00",
+            "Genehmigungsnummer": "260651"
+        }
+    },
+    {}
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-493304_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-493304_extracted.json
@@ -1,0 +1,110 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "MADISON Hotel GmbH",
+            "Address": "Schaarsteinweg 4, 20459 Hamburg",
+            "Contact": {
+                "Phone": "+49.40.37 666-0",
+                "Fax": "+49.40.37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Martina Head, Thomas Kleinertz",
+            "Register": "AG Hamburg HRB 47881",
+            "VAT": "DE118 686 407",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "BLZ": "200 300 00",
+                "Konto-Nr": "360 27 11",
+                "IBAN": "DE48 2003 0000 0003 6027 11",
+                "BIC": "HYVEDEMM300"
+            }
+        },
+        "Guest Information": {
+            "Company": "APImeiseter Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin",
+            "Guest Name": "Herr Jens Walter"
+        },
+        "Invoice Information": {
+            "Rechnungs-Nr.": "493304",
+            "Date": "15.03.19",
+            "Zimmer": "315",
+            "Anreise": "10.03.19",
+            "Abreise": "15.03.19",
+            "Seite": "1 of 1",
+            "Benutzer ID": "KUE"
+        },
+        "Charges": [
+            {
+                "Datum": "10.03.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "11.03.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "12.03.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "13.03.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "14.03.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 189.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "15.03.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": 629.0,
+                "Entlastung": null
+            }
+        ],
+        "Summary": {
+            "Umsatzsteuer Detail": {
+                "Netto EUR": 587.85,
+                "MwSt. EUR": 41.15,
+                "Brutto EUR": 629.0
+            },
+            "Total": {
+                "Total": 629.0,
+                "Saldo": "0.00 EUR"
+            }
+        },
+        "Payment Information": {
+            "Finanzamt": "Hamburg Mitte",
+            "Steuernummer": "4874/101/1228",
+            "Kreditkartendetails": {
+                "Kartennummer": "15484932",
+                "Beleg Nr.": "31933",
+                "Transaktionsbeleg": "629.00",
+                "Genehmigter Betrag": "629.00",
+                "Terminal ID": "68264893",
+                "Genehmigungsnummer": "624612"
+            }
+        }
+    },
+    {
+        "hotel_information": {
+            "name": "THE MADISON",
+            "location": "HAMBURG"
+        },
+        "guest_information": null,
+        "invoice_information": null,
+        "room_charges": null,
+        "taxes": null,
+        "total_charges": null
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-496987_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-496987_extracted.json
@@ -1,0 +1,128 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "MADISON Hotel GmbH",
+            "Address": "Schaarsteinweg 4, 20459 Hamburg, Germany",
+            "Contact": {
+                "Phone": "+49.40.37 666-0",
+                "Fax": "+49.40.37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Marlies Head, Thomas Kleinertz",
+            "Handelsregister": "AG Hamburg HRB 47881",
+            "VAT ID": "DE118 696 467",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "IBAN": "DE84 20030000 0003627111",
+                "BIC": "HYVEDEMM300"
+            }
+        },
+        "Guest Information": {
+            "Company": "APimeister Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin",
+            "Guest Name": "Herr Jens Walter"
+        },
+        "Invoice Information": {
+            "Invoice Number": "496987 /",
+            "Date": "18.04.19",
+            "Room Number": "439",
+            "Arrival Date": "15.04.19",
+            "Departure Date": "18.04.19",
+            "Page": "1 of 1",
+            "User ID": "LBE"
+        },
+        "Charges": [
+            {
+                "Datum": "15.04.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "16.04.19",
+                "Beschreibung": "Frühstück **",
+                "Belastung": 20.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "16.04.19",
+                "Beschreibung": "CHECK#1000540",
+                "Belastung": null,
+                "Entlastung": 20.0
+            },
+            {
+                "Datum": "16.04.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "17.04.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "18.04.19",
+                "Beschreibung": "Frühstück **",
+                "Belastung": 20.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "18.04.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": null,
+                "Entlastung": 370.0
+            }
+        ],
+        "Summary": {
+            "Umsatzsteuer Detail": [
+                {
+                    "MwSt. 7%": {
+                        "Netto EUR": 308.41,
+                        "MwSt. EUR": 21.59,
+                        "Brutto EUR": 330.0
+                    }
+                },
+                {
+                    "MwSt. 19%": {
+                        "Netto EUR": 33.61,
+                        "MwSt. EUR": 6.39,
+                        "Brutto EUR": 40.0
+                    }
+                }
+            ],
+            "Total": {
+                "Netto EUR": 342.02,
+                "MwSt. EUR": 27.98,
+                "Brutto EUR": 370.0
+            },
+            "Saldo": {
+                "Amount": 0.0,
+                "Currency": "EUR"
+            }
+        },
+        "Payment Information": {
+            "Kreditkartennr.": "XXXX XXXX XXXX 2825",
+            "Verfallsdatum": "XX/XX",
+            "Terminal ID": "6826492",
+            "Vertragspartner": "15649832",
+            "Beleg Nr.": "25903",
+            "Transaktionsbetrag": "370.00",
+            "Genehmigter Betrag": "370.00",
+            "Genehmigungscode": "960959"
+        }
+    },
+    {
+        "hotel_information": {
+            "name": "THE MADISON",
+            "location": "HAMBURG"
+        },
+        "guest_information": null,
+        "invoice_information": null,
+        "room_charges": null,
+        "taxes": null,
+        "total_charges": null
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-502875_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-502875_extracted.json
@@ -1,0 +1,93 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "MADISON Hotel GmbH",
+            "Address": "Schaarsteinweg 4, 20459 Hamburg",
+            "Contact": {
+                "Phone": "+49.40.37 666-0",
+                "Fax": "+49.40.37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Marlies Head, Thomas Kleinertz",
+            "AG Hamburg HRB": "47881",
+            "VAT ID": "DE118 690 407",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "BLZ": "200 300 00",
+                "Konto-Nr": "360 27 11",
+                "IBAN": "DE49 2003 0000 0036 0271 11",
+                "BIC": "HYVEDEMM300"
+            }
+        },
+        "Guest Information": {
+            "Name": "Herr Jens Walter",
+            "Company": "APIMeister Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin"
+        },
+        "Invoice Information": {
+            "Rechnungs-Nr.": "502875",
+            "Datum": "14.06.19",
+            "Zimmer": "426",
+            "Anreise": "10.06.19",
+            "Abreise": "14.06.19",
+            "Seite": "1 of 1",
+            "Benutzer ID": "BD"
+        },
+        "Charges": [
+            {
+                "Datum": "10.06.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "11.06.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "12.06.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "13.06.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "14.06.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": "440.00",
+                "Entlastung": null
+            }
+        ],
+        "Total": {
+            "Netto EUR": "411.21",
+            "MwSt. EUR": "28.79",
+            "Brutto EUR": "440.00",
+            "Saldo": "0.00 EUR"
+        },
+        "Umsatzsteuer Detail": {
+            "Total inkl. MwSt.": "411.21",
+            "MwSt. 7%": "28.79",
+            "Finanzamt": "Hamburg Mitte",
+            "Steuernummer": "47/841/01228"
+        },
+        "Kreditkartendetails": {
+            "Vertragspartnernummer": "15694832",
+            "Beleg Nr.": "27142",
+            "Kartenfolgenummer": "XXXXXXXXXXXX0502",
+            "Transaktionsbetrag": "440.00",
+            "Verfallsdatum": "XX/XX",
+            "Genehmigter Betrag": "440.00",
+            "Terminal ID": "89264892",
+            "Genehmigungscode": "366417"
+        }
+    },
+    {}
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-5036666_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/madison-5036666_extracted.json
@@ -1,0 +1,112 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "THE MADISON HAMBURG",
+            "Address": "Schaarsteinweg 4, 20459 Hamburg, Germany",
+            "Contact": {
+                "Phone": "+49-40-37 666-0",
+                "Fax": "+49-40-37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Martins Hadad, Thomas Kleinertz",
+            "AG Hamburg HRB": "47881",
+            "VAT": "DE118 696 407",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "IBAN": "DE 20 200 300 000 0360 0271 11",
+                "BIC": "HYVEDEMM300"
+            }
+        },
+        "Invoice Information": {
+            "Rechnungs-Nr.": "503666",
+            "Datum": "21.06.19",
+            "Zimmer": "435",
+            "Anreise": "16.06.19",
+            "Abreise": "21.06.19",
+            "Seite": "1 of 1",
+            "Benutzer ID": "BD"
+        },
+        "Guest Information": {
+            "Name": "Herr Jens Walter",
+            "Company": "APMeister Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin"
+        },
+        "Charges": [
+            {
+                "Datum": "16.06.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "17.06.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "18.06.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "19.06.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "20.06.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "21.06.19",
+                "Beschreibung": "Frühstück",
+                "Belastung": 20.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "21.06.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": 570.0,
+                "Entlastung": null
+            }
+        ],
+        "Total": {
+            "Netto EUR": 530.83,
+            "MwSt. EUR": 39.17,
+            "Brutto EUR": 570.0,
+            "Saldo": "0.00 EUR"
+        },
+        "Tax Details": {
+            "MwSt. 7%": {
+                "Netto EUR": 16.81,
+                "MwSt. EUR": 3.19,
+                "Brutto EUR": 20.0
+            },
+            "MwSt. 19%": {
+                "Netto EUR": 514.02,
+                "MwSt. EUR": 35.98,
+                "Brutto EUR": 550.0
+            }
+        },
+        "Payment Details": {
+            "Finanzamt": "Hamburg Mitte",
+            "Steuernummer": "48/741/04128",
+            "Kreditkartendetails": {
+                "Vertragspartner": "159484982",
+                "Kartenfolgenummer": "100000XXXXXX5052",
+                "Verfallsdatum": "XXXX",
+                "Terminal ID": "892484982",
+                "Beleg Nr.": "27411",
+                "Genehmigter Betrag": "570.00",
+                "Genehmigungscode": "623737"
+            }
+        }
+    },
+    {}
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/madison_497810_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/madison_497810_extracted.json
@@ -1,0 +1,97 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "MADISON Hotel GmbH",
+            "Address": "Schaarsteinweg 4, 20459 Hamburg",
+            "Contact": {
+                "Phone": "+49.40.37 666-0",
+                "Fax": "+49.40.37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Martens Heald, Thomas Kleinertz",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "IBAN": "DE48 2003 0000 0003 0671 111",
+                "BIC": "HYVEDEMM300"
+            },
+            "VAT": "DE118 686 407"
+        },
+        "Guest Information": {
+            "Company": "APImeiseter Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin",
+            "Guest Name": "Herr Jens Walter"
+        },
+        "Invoice Information": {
+            "Invoice Number": "497810 /",
+            "Date": "26.04.19",
+            "Room Number": "403",
+            "Check-in Date": "22.04.19",
+            "Check-out Date": "26.04.19",
+            "Page": "1 of 1",
+            "User ID": "RIL"
+        },
+        "Charges": [
+            {
+                "Datum": "22.04.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "23.04.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "24.04.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "25.04.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "26.04.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": null,
+                "Entlastung": 440.0
+            }
+        ],
+        "Total": {
+            "Netto EUR": 411.21,
+            "MwSt. EUR": 28.79,
+            "Brutto EUR": 440.0,
+            "Saldo": "0.00 EUR"
+        },
+        "Tax Details": {
+            "Total inkl. MwSt.": 411.21,
+            "MwSt. 7%": 28.79
+        },
+        "Financial Information": {
+            "Finanzamt": "Hamburg Mitte",
+            "Steuernummer": "48/741/00128"
+        },
+        "Credit Card Information": {
+            "Kreditkartendetails": "Mastercard",
+            "Verfallsdatum": "XXXX",
+            "Kreditkartennummer": "XXXXXXXXXXXX2825",
+            "Terminal ID": "6928491",
+            "Beleg Nr.": "7635",
+            "Transaktionsbetrag": "440.00",
+            "Genehmigungsnr.": "692849",
+            "Genehmigungscode": "692849"
+        }
+    },
+    {
+        "hotel_information": {
+            "name": "THE MADISON",
+            "location": "HAMBURG"
+        }
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/madison_folio_g_cp_efolio5895702_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/madison_folio_g_cp_efolio5895702_extracted.json
@@ -1,0 +1,92 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "MADISON Hotel GmbH",
+            "Address": "Schaartwiete 4, 20459 Hamburg",
+            "Contact": {
+                "Phone": "+49.40.37 666-0",
+                "Fax": "+49.40.37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Marlies Head, Thomas Kleinertz",
+            "AG Hamburg": "HRB 47281",
+            "VAT": "DE118 696 407",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "BLZ": "200 300 00",
+                "Konto-Nr": "360 27 11",
+                "IBAN": "DE48 2003 0000 0036 6027 11",
+                "BIC": "HYVEDEMM300"
+            }
+        },
+        "Guest Information": {
+            "Company": "APMeister Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin",
+            "Guest Name": "Herr Jens Walter"
+        },
+        "Invoice Information": {
+            "Rechnungs-Nr": "505050",
+            "Datum": "04.07.19",
+            "Zimmer": "203",
+            "Anreise": "30.06.19",
+            "Abreise": "04.07.19",
+            "Seite": "1 of 1",
+            "Benutzer ID": "RIL"
+        },
+        "Charges": [
+            {
+                "Datum": "30.06.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "01.07.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "02.07.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "03.07.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": "110.00",
+                "Entlastung": null
+            },
+            {
+                "Datum": "04.07.19",
+                "Beschreibung": "Bargeld",
+                "Belastung": null,
+                "Entlastung": "440.00"
+            }
+        ],
+        "Total": {
+            "Netto EUR": "411.21",
+            "MwSt. EUR": "28.79",
+            "Brutto EUR": "440.00",
+            "Saldo": "0.00 EUR"
+        },
+        "Umsatzsteuer Detail": {
+            "Total inkl. MwSt.": {
+                "Netto EUR": "411.21",
+                "MwSt. EUR": "28.79",
+                "Brutto EUR": "440.00"
+            },
+            "MwSt. 7%": {
+                "Netto EUR": "411.21",
+                "MwSt. EUR": "28.79",
+                "Brutto EUR": "440.00"
+            }
+        },
+        "Finanzamt": {
+            "Name": "Hamburg Mitte",
+            "Steuernummer": "48/741/01228"
+        }
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/madison_folio_g_cp_efolio5895707_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/madison_folio_g_cp_efolio5895707_extracted.json
@@ -1,0 +1,103 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "MADISON Hotel GmbH",
+            "Address": "Schaartestraße 4, 20459 Hamburg",
+            "Contact": {
+                "Phone": "+49.40.37 666-0",
+                "Fax": "+49.40.37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Marlies Head, Thomas Kleinertz",
+            "AG Hamburg HRB": "47281",
+            "VAT": "DE118 696 407",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "BLZ": "200 300 00",
+                "Konto-Nr": "360 27 11",
+                "IBAN": "DE84 2003 0000 0360 2711",
+                "BIC": "HYVEDEMM300"
+            }
+        },
+        "Guest Information": {
+            "Company": "APfmeister Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin",
+            "Guest Name": "Herr Jens Walter"
+        },
+        "Invoice Information": {
+            "Rechnungs-Nr.": "505050",
+            "Datum": "04.07.19",
+            "Zimmer": "203",
+            "Anreise": "30.06.19",
+            "Abreise": "04.07.19",
+            "Seite": "1 of 1",
+            "Benutzer ID": "RIL"
+        },
+        "Charges": [
+            {
+                "Datum": "30.06.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "01.07.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "02.07.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "03.07.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "04.07.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": null,
+                "Entlastung": 440.0
+            }
+        ],
+        "Total": {
+            "Netto EUR": 411.21,
+            "MwSt. EUR": 28.79,
+            "Brutto EUR": 440.0,
+            "Saldo": {
+                "Amount": 0.0,
+                "Currency": "EUR"
+            }
+        },
+        "Umsatzsteuer Detail": {
+            "Total inkl. MwSt.": {
+                "Netto EUR": 411.21,
+                "MwSt. EUR": 28.79,
+                "Brutto EUR": 440.0
+            },
+            "MwSt. 7%": {
+                "Netto EUR": 411.21,
+                "MwSt. EUR": 28.79,
+                "Brutto EUR": 440.0
+            }
+        },
+        "Payment Information": {
+            "Finanzamt": "Hamburg Mitte",
+            "Steuernummer": "48/741/00128",
+            "Kreditkartennr.": "156648932",
+            "Beleg Nr.": "8250",
+            "Kreditkartennummer": "XXXXXXXXXXXX5052",
+            "Transaktionsbetrag": 440.0,
+            "Verfallsdatum": "XX/XX",
+            "Genehmigter Betrag": 440.0,
+            "Terminal ID": "82664891",
+            "Genehmigungscode": "114540"
+        }
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/madison_folio_g_cp_efolio5945547_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/madison_folio_g_cp_efolio5945547_extracted.json
@@ -1,0 +1,105 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "MADISON Hotel GmbH",
+            "Address": "Schaartestraße 4, 20459 Hamburg",
+            "Contact": {
+                "Phone": "+49.40.37 666-0",
+                "Fax": "+49.40.37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Marlies Head, Thomas Kleinertz",
+            "Handelsregister": "AG Hamburg HRB 47281",
+            "VAT ID": "DE118 696 407",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "IBAN": "DE48 2003 0000 0003 6027 11",
+                "BIC": "HYVEDEMM300",
+                "Konto-Nr.": "360 27 11",
+                "BLZ": "200 300 00"
+            }
+        },
+        "Guest Information": {
+            "Company": "APfmeister Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin",
+            "Guest Name": "Herr Jens Walter"
+        },
+        "Invoice Information": {
+            "Rechnungs-Nr.": "506928",
+            "Date": "26.07.19",
+            "Room": "437",
+            "Anreise": "21.07.19",
+            "Abreise": "26.07.19",
+            "Seite": "1 of 1",
+            "Benutzer ID": "RF"
+        },
+        "Charges": [
+            {
+                "Datum": "21.07.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "22.07.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "23.07.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "24.07.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "25.07.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "26.07.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": null,
+                "Entlastung": 550.0
+            }
+        ],
+        "Summary": {
+            "Total inkl. MwSt.": {
+                "Netto EUR": 514.02,
+                "MwSt. EUR": 35.98,
+                "Brutto EUR": 550.0
+            },
+            "MwSt. 7%": {
+                "Netto EUR": 514.02,
+                "MwSt. EUR": 35.98,
+                "Brutto EUR": 550.0
+            },
+            "Total": 550.0,
+            "Saldo": "0.00 EUR"
+        },
+        "Payment Information": {
+            "Finanzamt": "Hamburg Mitte",
+            "Steuernummer": "48/741/00128",
+            "Kreditkarteninstitut": {
+                "Vertragspartner": "15648932",
+                "Beleg Nr.": "36856",
+                "Kreditkartennummer": "XXXXXXXXXXXX0502",
+                "Transaktionsbetrag": "550.00",
+                "Verfallsdatum": "XXXX",
+                "Genehmigter Betrag": "550.00",
+                "Terminal ID": "69264893",
+                "Genehmigungscode": "696152"
+            },
+            "Unterschrift": "Unterschrift des Karteninhabers"
+        }
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/madison_folio_g_cp_efolio5972171_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/madison_folio_g_cp_efolio5972171_extracted.json
@@ -1,0 +1,102 @@
+[
+    {
+        "hotel_information": {
+            "name": "MADISON Hotel GmbH",
+            "address": "Schaartinsweg 4, 20459 Hamburg",
+            "contact": {
+                "phone": "+49.40.37 666-0",
+                "fax": "+49.40.37 666-137",
+                "email": "info@madisonhotel.de",
+                "website": "madisonhotel.de"
+            },
+            "managing_directors": "Marlies Head, Thomas Kleinertz",
+            "registration": {
+                "court": "AG Hamburg HRB 47881",
+                "VAT_ID": "DE118 696 407"
+            },
+            "bank_details": {
+                "bank": "HypoVereinsbank",
+                "BLZ": "200 300 00",
+                "account_number": "360 27 11",
+                "IBAN": "DE48 2003 0000 0003 6027 11",
+                "BIC": "HYVEDEMM300"
+            }
+        },
+        "guest_information": {
+            "company": "APfmeister Consulting GmbH",
+            "address": "Friedrichstr. 123, 10117 Berlin",
+            "guest_name": "Herr Jens Walter"
+        },
+        "invoice_information": {
+            "invoice_number": "507536",
+            "date": "02.08.19",
+            "room_number": "631",
+            "check_in_date": "28.07.19",
+            "check_out_date": "02.08.19",
+            "page": "1 of 1",
+            "user_id": "KUE"
+        },
+        "charges": [
+            {
+                "date": "28.07.19",
+                "description": "Übernachtung exklusive Frühstück*",
+                "charge": 110.0,
+                "credit": null
+            },
+            {
+                "date": "29.07.19",
+                "description": "Übernachtung exklusive Frühstück*",
+                "charge": 110.0,
+                "credit": null
+            },
+            {
+                "date": "30.07.19",
+                "description": "Übernachtung exklusive Frühstück*",
+                "charge": 110.0,
+                "credit": null
+            },
+            {
+                "date": "31.07.19",
+                "description": "Übernachtung exklusive Frühstück*",
+                "charge": 110.0,
+                "credit": null
+            },
+            {
+                "date": "01.08.19",
+                "description": "Übernachtung exklusive Frühstück*",
+                "charge": 110.0,
+                "credit": null
+            },
+            {
+                "date": "02.08.19",
+                "description": "Mastercard IFC",
+                "charge": null,
+                "credit": 550.0
+            }
+        ],
+        "summary": {
+            "total_net_eur": 514.02,
+            "total_vat_eur": 35.98,
+            "total_gross_eur": 550.0,
+            "total_charge": 550.0,
+            "total_credit": 550.0,
+            "balance_due": 0.0
+        },
+        "payment_information": {
+            "tax_office": "Finanzamt: Hamburg Mitte",
+            "tax_number": "47/841/01228",
+            "credit_card_details": {
+                "card_type": "Mastercard",
+                "card_number": "XXXX XXXX XXXX 5052",
+                "transaction_number": "550.00",
+                "authorization_code": "949052",
+                "terminal_id": "62684952",
+                "approval_code": "949052"
+            },
+            "reference_number": "154684932",
+            "receipt_number": "28866",
+            "authorization": "Ich authorisiere den aufgeführten Betrag.",
+            "signature": "Unterschrift des Karteninhabers"
+        }
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/madison_folio_g_cp_efolio5976009_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/madison_folio_g_cp_efolio5976009_extracted.json
@@ -1,0 +1,114 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "MADISON Hotel GmbH",
+            "Address": "Schaartorweg 4, 20459 Hamburg, Germany",
+            "Contact": {
+                "Phone": "+49.40.37 666-0",
+                "Fax": "+49.40.37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Marlies Head, Thomas Kleinertz",
+            "AG Hamburg HRB": "47281",
+            "VAT": "DE118 696 407",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "IBAN": "DE40 2003 0000 0003 6027 11",
+                "BIC": "HYVEDEMM300"
+            }
+        },
+        "Guest Information": {
+            "Company": "APMeister Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin",
+            "Guest Name": "Herr Jens Walter"
+        },
+        "Invoice Information": {
+            "Rechnungs-Nr.": "508189",
+            "Datum": "09.08.19",
+            "Zimmer": "438",
+            "Anreise": "04.08.19",
+            "Abreise": "09.08.19",
+            "Seite": "1 of 1",
+            "Benutzer ID": "WM"
+        },
+        "Charges": [
+            {
+                "Datum": "04.08.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "05.08.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "06.08.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "07.08.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "08.08.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "09.08.19",
+                "Beschreibung": "Frühstück **",
+                "Belastung": 20.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "09.08.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": null,
+                "Entlastung": 570.0
+            }
+        ],
+        "Summary": {
+            "Total Netto EUR": 530.83,
+            "Total MwSt. EUR": 39.17,
+            "Total Brutto EUR": 570.0,
+            "MwSt. 19%": {
+                "Netto EUR": 16.81,
+                "MwSt. EUR": 3.19,
+                "Brutto EUR": 20.0
+            },
+            "MwSt. 7%": {
+                "Netto EUR": 514.02,
+                "MwSt. EUR": 35.98,
+                "Brutto EUR": 550.0
+            },
+            "Saldo": {
+                "Amount": 0.0,
+                "Currency": "EUR"
+            }
+        },
+        "Financial Information": {
+            "Finanzamt": "Hamburg Mitte",
+            "Steuernummer": "4874/101/0228"
+        },
+        "Credit Card Information": {
+            "Vertragspartner-ID": "154654932",
+            "Kartenfolgenummer": "XXXXXX",
+            "Kreditkartennummer": "XXXXXXXXXXXX5052",
+            "Verfallsdatum": "XXXX",
+            "Terminal ID": "52964893",
+            "Beleg Nr.": "93935",
+            "Transaktionsbetrag": "570.00",
+            "Genehmigter Betrag": "570.00",
+            "Genehmigungscode": "165942"
+        }
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/madison_folio_g_cp_efolio5991896_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/madison_folio_g_cp_efolio5991896_extracted.json
@@ -1,0 +1,103 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "MADISON Hotel GmbH",
+            "Address": "Schaartinsweg 4, 20459 Hamburg",
+            "Contact": {
+                "Phone": "+49.40.37 666-0",
+                "Fax": "+49.40.37 666-137",
+                "Email": "info@madisonhotel.de",
+                "Website": "madisonhotel.de"
+            },
+            "Geschäftsführer": "Marlies Head, Thomas Kleinertz",
+            "AG Hamburg": "HRB 47821",
+            "VAT": "DE118 696 407",
+            "Bank": {
+                "Name": "HypoVereinsbank",
+                "BLZ": "200 300 00",
+                "Konto-Nr": "360 27 11",
+                "IBAN": "DE48 2003 0000 0360 0271 11",
+                "BIC": "HYVEDEMM300"
+            }
+        },
+        "Guest Information": {
+            "Company": "APMeister Consulting GmbH",
+            "Address": "Friedrichstr. 123, 10117 Berlin",
+            "Guest Name": "Herr Jens Walter"
+        },
+        "Invoice Information": {
+            "Rechnungs-Nr.": "508873 /",
+            "Date": "16.08.19",
+            "Room": "407",
+            "Arrival": "11.08.19",
+            "Departure": "16.08.19",
+            "Page": "1 of 1",
+            "User ID": "RF"
+        },
+        "Charges": [
+            {
+                "Datum": "11.08.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "12.08.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "13.08.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "14.08.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "15.08.19",
+                "Beschreibung": "Übernachtung exklusive Frühstück*",
+                "Belastung": 110.0,
+                "Entlastung": null
+            },
+            {
+                "Datum": "16.08.19",
+                "Beschreibung": "Mastercard IFC",
+                "Belastung": 550.0,
+                "Entlastung": null
+            }
+        ],
+        "Summary": {
+            "Total inkl. MwSt.": {
+                "Netto EUR": 514.02,
+                "MwSt. EUR": 35.98,
+                "Brutto EUR": 550.0
+            },
+            "MwSt. 7%": {
+                "Netto EUR": 514.02,
+                "MwSt. EUR": 35.98,
+                "Brutto EUR": 550.0
+            },
+            "Total": 550.0,
+            "Saldo": "0.00 EUR"
+        },
+        "Payment Information": {
+            "Kreditkarteninstitut": "Finanzamt: Hamburg Mitte",
+            "Steuernummer": "47/841/01128",
+            "Vertragspartner": "154694832",
+            "Beleg Nr.": "39659",
+            "Kartenknummer": "XXXXXXXXXXXX0502",
+            "Transaktionsbetrag": "550.00",
+            "Verfallsdatum": "XXXX",
+            "Genehmigter Betrag": "550.00",
+            "Terminal ID": "692648593",
+            "Genehmigungscode": "750675",
+            "Unterschrift": "Unterschrift des Karteninhabers"
+        }
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/mercure-37816396_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/mercure-37816396_extracted.json
@@ -1,0 +1,57 @@
+[
+    {
+        "hotel_information": {
+            "name": "Mercure Hotel Bochum City",
+            "address": "Massenbergstrasse 19-21, 44787 Bochum",
+            "contact": {
+                "phone": "+49 234 9690",
+                "fax": "+49 234 9692222",
+                "email": "H0707@accor.com",
+                "website": "mercure.com | accorhotels.com"
+            }
+        },
+        "guest_information": {
+            "company": "Apimeister Consulting GmbH",
+            "address": "Friedrichstrasse 123, 10117 Berlin, Germany",
+            "guest_name": "Herrn Jens Walter"
+        },
+        "invoice_information": {
+            "invoice_number": "HA007 - 123123 - 37816396",
+            "date": "05.07.19",
+            "page": "1 von 1",
+            "user_id": "IWINKING",
+            "room_number": "1307",
+            "arrival_date": "04.07.19",
+            "departure_date": "05.07.19"
+        },
+        "charges": [
+            {
+                "date": "04.07.19",
+                "description": "Übernachtung",
+                "charge": 118.0,
+                "credit": null
+            },
+            {
+                "date": "05.07.19",
+                "description": "Mastercard",
+                "charge": null,
+                "credit": 118.0
+            }
+        ],
+        "summary": {
+            "total_incl_vat": {
+                "net_amount": 110.28,
+                "vat_amount": 7.72,
+                "gross_amount": 118.0
+            },
+            "vat_7_percent": {
+                "net_amount": 110.28,
+                "vat_amount": 7.72,
+                "gross_amount": 118.0
+            },
+            "total": 118.0,
+            "balance": 0.0
+        },
+        "message": "Vielen Dank für Ihren Aufenthalt im Mercure Bochum City. Wir wünschen Ihnen eine gute Heimreise und freuen uns schon heute auf einen erneuten Besuch in unserem Hotel. Ihr Mercure Hotel Bochum City."
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/motelone-524544306_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/motelone-524544306_extracted.json
@@ -1,0 +1,92 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "Motel One Berlin-Tiergarten",
+            "Address": "An der Urania 12/14 - 10787 Berlin"
+        },
+        "Guest Information": {
+            "Name": "Apimeister Consulting GmbH",
+            "Address": "Friedrichstrasse 123, 10117 Berlin, Deutschland"
+        },
+        "Invoice Information": {
+            "Datum": "25.02.2019",
+            "Rechnungsnummer": "524544306",
+            "Reservierungsnummer": "524414809/1",
+            "Zimmer": "519",
+            "Anreise": "25.02.2019",
+            "Abreise": "27.02.2019"
+        },
+        "Charges": {
+            "Gast": "Walter, Jens",
+            "Zimmer": "519",
+            "Zeitraum": "25.02.2019 bis 27.02.2019",
+            "Leistungen": [
+                {
+                    "Bezeichnung": "Best Public Rate mit Frühstück",
+                    "MWST-Satz": null,
+                    "Menge": 2,
+                    "Einzelpreis EUR": 80.5,
+                    "Gesamtpreis EUR": 161.0
+                },
+                {
+                    "Bezeichnung": "Frühstück",
+                    "MWST-Satz": "19,00%",
+                    "Menge": 2,
+                    "Einzelpreis EUR": 11.5,
+                    "Gesamtpreis EUR": 23.0
+                },
+                {
+                    "Bezeichnung": "Logis",
+                    "MWST-Satz": "7,00%",
+                    "Menge": 2,
+                    "Einzelpreis EUR": 69.0,
+                    "Gesamtpreis EUR": 138.0
+                }
+            ],
+            "Saldo Leistungen": {
+                "Währung": "EUR",
+                "Betrag": 161.0
+            }
+        },
+        "Payments": {
+            "Datum": "25.02.2019",
+            "Zahlungsart": "Mastercard",
+            "Karten-Nr.": "****2825",
+            "Betrag Devisen": null,
+            "Zahlung EUR": -161.0
+        },
+        "Saldo Zahlungen": -161.0,
+        "Rechnungsbetrag": 0.0,
+        "Steuerbeträge": [
+            {
+                "Steuersatz": "19,00%",
+                "Netto EUR": 19.33,
+                "Steuer EUR": 3.67,
+                "Brutto EUR": 23.0
+            },
+            {
+                "Steuersatz": "7,00%",
+                "Netto EUR": 128.97,
+                "Steuer EUR": 9.03,
+                "Brutto EUR": 138.0
+            }
+        ],
+        "WLAN-Zugangsdaten": {
+            "Einfach AGB bestätigen und lossurfen!": null,
+            "WLAN-Support gewünscht?": null,
+            "Kostenlose Hotline aus Deutschland": "0800-4357526",
+            "Kostenlose Hotline aus anderen Ländern": "+49-241-70530965"
+        },
+        "Hotel Manager": {
+            "Name": "Sebastian Gahm",
+            "Title": "Front Office Manager"
+        },
+        "Additional Information": {
+            "Newly Opened": [
+                "Motel One Bonn-Beethoven",
+                "Motel One Leipzig-Post"
+            ]
+        }
+    },
+    {}
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/motelone_20191111_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/motelone_20191111_extracted.json
@@ -1,0 +1,107 @@
+[
+    {
+        "hotel_information": {
+            "name": "Motel One Stuttgart-Bad Cannstatt",
+            "address": "Badstraße 20, 70372 Stuttgart"
+        },
+        "guest_information": {
+            "name": "Apimeister consulting GmbH",
+            "address": "Friedrichstrasse 123, 10117 Berlin, Germany"
+        },
+        "invoice_information": {
+            "date": "11.11.2019",
+            "invoice_number": "548113542",
+            "reservation_number": "548098589/1",
+            "room": "330",
+            "arrival": "11.11.2019",
+            "departure": "12.11.2019"
+        },
+        "charges": [
+            {
+                "guest": "Apimeister consulting GmbH",
+                "service": "Deposit 548113520/02 vom 11.11.19",
+                "VAT": "null",
+                "num": "-1",
+                "price_EUR": "90,50",
+                "amount_EUR": "-90,50"
+            },
+            {
+                "guest": "Apimeister consulting GmbH",
+                "service": "Frühstück",
+                "VAT": "19,00%",
+                "num": "1",
+                "price_EUR": "11,50",
+                "amount_EUR": "11,50"
+            },
+            {
+                "guest": "Apimeister consulting GmbH",
+                "service": "Lodging",
+                "VAT": "7,00%",
+                "num": "1",
+                "price_EUR": "79,00",
+                "amount_EUR": "79,00"
+            },
+            {
+                "guest": "Walter, Jens",
+                "room": "330",
+                "date_range": "11.11.2019 to 12.11.2019",
+                "service": "Best Price including Breakfast",
+                "VAT": "null",
+                "num": "1",
+                "price_EUR": "90,50",
+                "amount_EUR": "90,50"
+            },
+            {
+                "guest": "Walter, Jens",
+                "room": "330",
+                "date_range": "11.11.2019 to 12.11.2019",
+                "service": "Frühstück",
+                "VAT": "19,00%",
+                "num": "1",
+                "price_EUR": "11,50",
+                "amount_EUR": "11,50"
+            },
+            {
+                "guest": "Walter, Jens",
+                "room": "330",
+                "date_range": "11.11.2019 to 12.11.2019",
+                "service": "Lodging",
+                "VAT": "7,00%",
+                "num": "1",
+                "price_EUR": "79,00",
+                "amount_EUR": "79,00"
+            }
+        ],
+        "total_amount": {
+            "currency": "EUR",
+            "amount": "0,00"
+        },
+        "payment_information": {
+            "date": "null",
+            "payment": "null",
+            "card_number": "null",
+            "amount_currency": "null",
+            "payment_EUR": "null"
+        },
+        "balance_to_pay": {
+            "currency": "EUR",
+            "amount": "0,00"
+        },
+        "VAT_information": {
+            "19,00%": {
+                "net_amount_EUR": "0,00",
+                "VAT_amount_EUR": "0,00",
+                "VAT_gross_EUR": "0,00"
+            },
+            "7,00%": {
+                "net_amount_EUR": "0,00",
+                "VAT_amount_EUR": "0,00",
+                "VAT_gross_EUR": "0,00"
+            }
+        },
+        "staff_information": {
+            "name": "Sarah Golombiewski",
+            "position": "Front Office Agent"
+        }
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/motelone_20191118_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/motelone_20191118_extracted.json
@@ -1,0 +1,88 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "Motel One Berlin-Hauptbahnhof",
+            "Address": "Invalidenstraße 54, 10557 Berlin"
+        },
+        "Guest Information": {
+            "Name": "APImeiseter Consulting GmbH",
+            "Address": "Friedrichstrasse 123, 10117 Berlin, Deutschland"
+        },
+        "Invoice Information": {
+            "Datum": "18.11.2019",
+            "Rechnungsnummer": "534717906",
+            "Reservierungsnummer": "534629153/1",
+            "Zimmer": "1011",
+            "Anreise": "18.11.2019",
+            "Abreise": "19.11.2019"
+        },
+        "Charges": {
+            "Gast": "Walter, Jens",
+            "Zimmer": "1011",
+            "von": "18.11.2019",
+            "bis": "19.11.2019",
+            "Items": [
+                {
+                    "Bezeichnung": "Bestpreis mit Frühstück",
+                    "MWST-Satz": null,
+                    "Menge": "1",
+                    "Einzelpreis EUR": "80,50",
+                    "Gesamtpreis EUR": "80,50"
+                },
+                {
+                    "Bezeichnung": "Frühstück",
+                    "MWST-Satz": "19,00%",
+                    "Menge": "1",
+                    "Einzelpreis EUR": "11,50",
+                    "Gesamtpreis EUR": "11,50"
+                },
+                {
+                    "Bezeichnung": "Logis",
+                    "MWST-Satz": "7,00%",
+                    "Menge": "1",
+                    "Einzelpreis EUR": "69,00",
+                    "Gesamtpreis EUR": "69,00"
+                }
+            ],
+            "Saldo Leistungen": {
+                "EUR": "80,50"
+            }
+        },
+        "Payments": [
+            {
+                "Datum": "18.11.2019",
+                "Zahlungsart": "Mastercard",
+                "Karten-Nr.": "************5052",
+                "Betrag Devisen": null,
+                "Zahlung EUR": "-80,50"
+            }
+        ],
+        "Saldo Zahlungen": "-80,50",
+        "Rechnungsbetrag": "0,00",
+        "Steuerbeträge": [
+            {
+                "Steuersatz": "19,00 % (MwSt)",
+                "Netto EUR": "9,66",
+                "Steuer EUR": "1,84",
+                "Brutto EUR": "11,50"
+            },
+            {
+                "Steuersatz": "7,00 % (MwSt)",
+                "Netto EUR": "64,49",
+                "Steuer EUR": "4,51",
+                "Brutto EUR": "69,00"
+            }
+        ],
+        "WLAN-Zugangsdaten": {
+            "Einfach AGB bestätigen und lossurfen!": null,
+            "WLAN-Support gewünscht?": {
+                "Kostenlose Hotline aus Deutschland": "0800-4357576",
+                "Kostenlose Hotline aus anderen Ländern": "+49-241-70539605"
+            }
+        },
+        "Front Office Agent": {
+            "Name": "Daniel Martelock"
+        },
+        "Additional Information": "Jetzt eröffnet: Motel One München-Haidhausen!"
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/moxy-20191221_007_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/moxy-20191221_007_extracted.json
@@ -1,0 +1,103 @@
+[
+    {
+        "hotel_information": {
+            "name": "MOXY Frankfurt Airport",
+            "address": "Amelia-Mary-Earhart-Strasse 5, 60549 Frankfurt/Main",
+            "contact": {
+                "phone": "+49 69 96759139",
+                "fax": "+49 69 96759139",
+                "email": "crew.frankfurt@moxyhotels.com",
+                "website": "www.moxyfrankfurtairport.com"
+            }
+        },
+        "guest_information": {
+            "name": "Maik Walter",
+            "company": "Pfmeister Consulting GmbH",
+            "address": "Friedrichstr. 123, 10117 Berlin, Germany",
+            "room_number": "306",
+            "arrival_date": "30.11.19",
+            "departure_date": "01.12.19",
+            "folio_number": "227639",
+            "confirmation_number": "85111762",
+            "cashier_number": "8370",
+            "invoice_date": "01.12.19"
+        },
+        "invoice_information": {
+            "description": [
+                {
+                    "date": "21.11.19",
+                    "description": "Deposit Tax Transfer",
+                    "debit_eur": null,
+                    "credit_eur": "3.14"
+                },
+                {
+                    "date": "30.11.19",
+                    "description": "Accommodation",
+                    "debit_eur": "48.00",
+                    "credit_eur": null
+                },
+                {
+                    "date": "30.11.19",
+                    "description": "Deposit Transfer at C/I",
+                    "debit_eur": null,
+                    "credit_eur": "44.86"
+                }
+            ],
+            "deposit_folio": [
+                {
+                    "date": "21.11.19",
+                    "folio_number": "223554",
+                    "deposit_amount": "48.00",
+                    "vat": "3.14"
+                }
+            ],
+            "total": {
+                "debit_eur": "48.00",
+                "credit_eur": "48.00",
+                "balance_to_pay": "0.00"
+            }
+        },
+        "vat_details": {
+            "total_incl_vat": {
+                "net_eur": "44.86",
+                "vat_eur": "3.14",
+                "gross_eur": "48.00"
+            },
+            "vat_7_percent": {
+                "net_eur": "44.86",
+                "vat_eur": "3.14",
+                "gross_eur": "48.00"
+            },
+            "deposit_7_percent": {
+                "net_eur": "44.86",
+                "vat_eur": "-3.14",
+                "gross_eur": "48.00"
+            }
+        },
+        "credit_card_details": {
+            "merchant_number": null,
+            "card_number": "XXXXXXXXXXXX5052",
+            "expiry_date": "XX/XX",
+            "card_entry": null,
+            "verification": null,
+            "terminal_id": null,
+            "receipt_number": null,
+            "transaction_amount": "48.00",
+            "approval_amount": "48.00",
+            "approval_code": "A311243"
+        },
+        "entity_information": {
+            "name": "QMHotel Germany GmbH",
+            "chamber_of_commerce_number": "HRB 207980",
+            "location": "MÜNCHEN",
+            "fiscal_number": "143/179/72007",
+            "vat_id_number": "UID DE294499203",
+            "authorized_representative": "Rune Firing",
+            "bank": {
+                "name": "NORDEA BANK A/S",
+                "iban": "DE23 6143 0030 6869 0400 01",
+                "swift_code": "NDEADEFF"
+            }
+        }
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/moxy_20191221_006_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/moxy_20191221_006_extracted.json
@@ -1,0 +1,102 @@
+[
+    {
+        "hotel_information": {
+            "name": "MOXY Frankfurt Airport",
+            "address": "Amelia-Mary-Earhart-Strasse 5, 60549 Frankfurt/Main",
+            "phone": "+49 (0) 69 96759119",
+            "email": "crew.frankfurtairport@moxyhotels.com",
+            "website": "www.moxyfrankfurtairport.com"
+        },
+        "guest_information": {
+            "name": "Jens Walter",
+            "company": "API Meister Consulting GmbH",
+            "address": "Friedrichstr. 123, 10117 Berlin, Germany",
+            "room_no": "305",
+            "arrival_date": "30.11.19",
+            "departure_date": "01.12.19",
+            "folio_no": "227638",
+            "confirmation_no": "85111510",
+            "cashier_no": "8370",
+            "invoice_date": "01.12.19"
+        },
+        "invoice_information": {
+            "date": "01.12.19",
+            "description": "INVOICE"
+        },
+        "charges": [
+            {
+                "date": "21.11.19",
+                "description": "Deposit Tax Transfer",
+                "debit_eur": null,
+                "credit_eur": "3.14"
+            },
+            {
+                "date": "30.11.19",
+                "description": "Accommodation",
+                "debit_eur": "48.00",
+                "credit_eur": null
+            },
+            {
+                "date": "30.11.19",
+                "description": "Deposit Transfer at C/I",
+                "debit_eur": null,
+                "credit_eur": "44.86"
+            }
+        ],
+        "deposit_information": [
+            {
+                "date": "21.11.19",
+                "deposit_folio_no": "225353",
+                "deposit_amount": "48.00",
+                "vat": "3.14"
+            }
+        ],
+        "totals": {
+            "total": "48.00",
+            "balance_to_pay": "0.00"
+        },
+        "vat_details": {
+            "total_incl_vat": {
+                "net_eur": "44.86",
+                "vat_eur": "3.14",
+                "gross_eur": "48.00"
+            },
+            "vat_7_percent": {
+                "net_eur": "44.86",
+                "vat_eur": "3.14",
+                "gross_eur": "48.00"
+            },
+            "deposit_7_percent": {
+                "net_eur": "44.86",
+                "vat_eur": "3.14",
+                "gross_eur": "-48.00"
+            }
+        },
+        "credit_card_details": {
+            "merchant_no": null,
+            "credit_card_no": "XXXXXXXXXXXX5052",
+            "expiry_date": "XX/XX",
+            "card_entry": null,
+            "verification": null,
+            "terminal_id": null,
+            "receipt_no": null,
+            "transaction_amount": "48.00",
+            "approval_amount": "48.00",
+            "approval_code": "A1848003"
+        },
+        "signature": {
+            "card_holder": null
+        },
+        "entity_information": {
+            "name": "QMHotel Germany GmbH",
+            "chamber_of_commerce_number": "HRB 207980",
+            "registered_office": "MÜNCHEN",
+            "fiscal_number": "143/317/7200",
+            "vat_id_number": "UID DE294499203",
+            "authorized_representative": "Rune Fring",
+            "bank": "NORDEA BANK AB",
+            "iban": "DE25 3143 5030 6889 0400 01",
+            "swift_code": "NDEADEFF"
+        }
+    }
+]

--- a/examples/data/hotel_invoices/extracted_invoice_json_raw/premierinn_GABCI19014325_extracted.json
+++ b/examples/data/hotel_invoices/extracted_invoice_json_raw/premierinn_GABCI19014325_extracted.json
@@ -1,0 +1,113 @@
+[
+    {
+        "Hotel Information": {
+            "Name": "Hamburg City (Zentrum)",
+            "Address": "Willy-Brandt-Straße 21, 20457 Hamburg, Deutschland",
+            "Phone": "+49 (0) 40 3039 379 0"
+        },
+        "Guest Information": {
+            "Name": "APIMEISTER CONSULTING GmbH",
+            "Guest": "Herr Jens Walter",
+            "Address": "Friedrichstr. 123, 10117 Berlin"
+        },
+        "Invoice Information": {
+            "Rechnungsnummer": "GABC19014325",
+            "Rechnungsdatum": "23.09.19",
+            "Referenznummer": "GABC015452127",
+            "Buchungsnummer": "GABR15867",
+            "Ankunft": "23.09.19",
+            "Abreise": "27.09.19",
+            "Nächte": 4,
+            "Zimmer": 626,
+            "Kundereferenz": 2
+        },
+        "Charges": [
+            {
+                "Datum": "23.09.19",
+                "Uhrzeit": "16:36",
+                "Beschreibung": "Übernachtung",
+                "MwSt.%": 7.0,
+                "Betrag": 77.0,
+                "Zahlung": null
+            },
+            {
+                "Datum": "24.09.19",
+                "Uhrzeit": null,
+                "Beschreibung": "Übernachtung",
+                "MwSt.%": 7.0,
+                "Betrag": 135.0,
+                "Zahlung": null
+            },
+            {
+                "Datum": "25.09.19",
+                "Uhrzeit": null,
+                "Beschreibung": "Übernachtung",
+                "MwSt.%": 7.0,
+                "Betrag": 82.0,
+                "Zahlung": null
+            },
+            {
+                "Datum": "26.09.19",
+                "Uhrzeit": null,
+                "Beschreibung": "Übernachtung",
+                "MwSt.%": 7.0,
+                "Betrag": 217.0,
+                "Zahlung": null
+            },
+            {
+                "Datum": "24.09.19",
+                "Uhrzeit": "9:50",
+                "Beschreibung": "Premier Inn Frühstücksbuffet",
+                "MwSt.%": 19.0,
+                "Betrag": 9.9,
+                "Zahlung": null
+            },
+            {
+                "Datum": "25.09.19",
+                "Uhrzeit": "9:50",
+                "Beschreibung": "Premier Inn Frühstücksbuffet",
+                "MwSt.%": 19.0,
+                "Betrag": 9.9,
+                "Zahlung": null
+            },
+            {
+                "Datum": "26.09.19",
+                "Uhrzeit": "9:50",
+                "Beschreibung": "Premier Inn Frühstücksbuffet",
+                "MwSt.%": 19.0,
+                "Betrag": 9.9,
+                "Zahlung": null
+            },
+            {
+                "Datum": "27.09.19",
+                "Uhrzeit": "9:50",
+                "Beschreibung": "Premier Inn Frühstücksbuffet",
+                "MwSt.%": 19.0,
+                "Betrag": 9.9,
+                "Zahlung": null
+            }
+        ],
+        "Payment Information": {
+            "Zahlung": "550,60",
+            "Gesamt (Rechnungsbetrag)": "550,60",
+            "Offener Betrag": "0,00",
+            "Bezahlart": "Mastercard-Kreditkarte"
+        },
+        "Tax Information": {
+            "MwSt.%": [
+                {
+                    "Rate": 19.0,
+                    "Netto": 33.28,
+                    "MwSt.": 6.32,
+                    "Brutto": 39.6
+                },
+                {
+                    "Rate": 7.0,
+                    "Netto": 477.57,
+                    "MwSt.": 33.43,
+                    "Brutto": 511.0
+                }
+            ]
+        }
+    }
+]


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2468](https://github.com/openai/openai-cookbook/pull/2468)
> **Original author:** @DhruvTilva
> **Originally opened:** 2026-02-26

---

Fixes #1418, #1934, #1837, #1635

## Problem
Cloning this repo on Windows fails with:

error: invalid path 'examples/data/hotel_invoices/extracted_invoice_json /20190119_002_extracted.json'
fatal: unable to checkout working tree

<img width="1661" height="324" alt="image" src="https://github.com/user-attachments/assets/e4f7cd0f-a50f-4967-8f17-76b671923cd8" />

The directory `extracted_invoice_json ` (with trailing space) is invalid on Windows NTFS.
This has been reported in 4 separate issues dating back to 2024 and affects every Windows user.

## Root Cause
There are two directories with similar names containing DISTINCT data:
- `extracted_invoice_json/` → normalized English fields (used by notebook)
- `extracted_invoice_json /` → raw German fields e.g. `Rechnungs-Nr`, `Zimmer` (trailing space = Windows invalid path)

## Fix
Rename `extracted_invoice_json /` (trailing space) → `extracted_invoice_json_raw/`

This approach:
- ✅ Fixes the Windows clone failure (removes the invalid trailing space)
- ✅ Preserves all 31 files and their distinct data
- ✅ Makes the relationship between directories clearer (`_raw` = source data)

## Before vs After

| | Before | After |
|---|---|---|
| Windows clone | ❌ Fatal error | ✅ Works |
| Data preserved | ❌ Files at risk | ✅ All 31 files kept under `extracted_invoice_json_raw/` |
| Notebook broken | No | No (still uses `extracted_invoice_json/`) |

## Notes
- Previous PR #2071 deleted the directory — closed as stale Jan 2026 without merge
- This PR improves on that approach by renaming instead of deleting, preserving the raw dataset
- Codex bot review on this PR correctly flagged the data difference — this commit addresses that feedback
