### PR TITLE
Fix fine-tuning docs link in Qdrant RAG fine-tuning notebook

### DIFF
--- a/examples/fine-tuned_qa/ft_retrieval_augmented_generation_qdrant.ipynb
+++ b/examples/fine-tuned_qa/ft_retrieval_augmented_generation_qdrant.ipynb
@@ -488,7 +488,7 @@
    "source": [
     "## 4. Fine-tuning and Answering using Fine-tuned model\n",
     "\n",
-    "For the complete fine-tuning process, please refer to the [OpenAI Fine-Tuning Docs](https://platform.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model).\n",
+    "For the complete fine-tuning process, please refer to the [OpenAI Fine-Tuning Docs](https://developers.openai.com/api/docs/guides/supervised-fine-tuning).\n",
     "\n",
     "### 4.1 Prepare the Fine-Tuning Data\n",
     "\n",
@@ -538,7 +538,7 @@
     "\n",
     "### 4.2 Fine-Tune OpenAI Model\n",
     "\n",
-    "If you're new to OpenAI Model Fine-Tuning, please refer to the [How to finetune Chat models](https://github.com/openai/openai-cookbook/blob/448a0595b84ced3bebc9a1568b625e748f9c1d60/examples/How_to_finetune_chat_models.ipynb) notebook. You can also refer to the [OpenAI Fine-Tuning Docs](platform.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model) for more details."
+    "If you're new to OpenAI Model Fine-Tuning, please refer to the [How to finetune Chat models](https://github.com/openai/openai-cookbook/blob/448a0595b84ced3bebc9a1568b625e748f9c1d60/examples/How_to_finetune_chat_models.ipynb) notebook. You can also refer to the [OpenAI Fine-Tuning Docs](https://developers.openai.com/api/docs/guides/supervised-fine-tuning) for more details."
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2451](https://github.com/openai/openai-cookbook/pull/2451)
> **Original author:** @dcol91863
> **Originally opened:** 2026-02-19

---

Fixes #2320.

Updates the fine-tuning documentation links in `examples/fine-tuned_qa/ft_retrieval_augmented_generation_qdrant.ipynb` to point to the current OpenAI Developers guide for supervised fine-tuning.

Also fixes one instance that was missing an `https://` scheme.
