### PR TITLE
Remove duplicate sentence in Eval-Driven System Design cookbook

### DIFF
--- a/examples/partners/eval_driven_system_design/receipt_inspection.ipynb
+++ b/examples/partners/eval_driven_system_design/receipt_inspection.ipynb
@@ -515,10 +515,7 @@
     "\n",
     "For this cookbook, `o3` might be too good. We'll use `o4-mini` for our first pass, so \n",
     "that we get a few reasoning errors we can use to illustrate the means of addressing\n",
-    "them when they occur.\n",
-    "\n",
-    "Next, we need to close the loop and get to an actual decision based on receipts. This\n",
-    "looks pretty similar, so we'll present the code without comment."
+    "them when they occur."
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2406](https://github.com/openai/openai-cookbook/pull/2406)
> **Original author:** @adayNU
> **Originally opened:** 2026-01-28

---

## Summary

Removes a verbatim sentence one paragraph after it first appears.

## Motivation

Improving clarity.
