### PR TITLE
Remove conflicting instruction from prompt prefix in bulk-experimentation notebook

### DIFF
--- a/examples/evaluation/use-cases/bulk-experimentation.ipynb
+++ b/examples/evaluation/use-cases/bulk-experimentation.ipynb
@@ -322,8 +322,6 @@
     "<push_notifications>\n",
     "...notificationlist...\n",
     "</push_notifications>\n",
-    "\n",
-    "You should return just the summary and nothing else.\n",
     "\"\"\"\n",
     "\n",
     "PROMPT_VARIATION_BASIC = f\"\"\"\n",


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2342](https://github.com/openai/openai-cookbook/pull/2342)
> **Original author:** @heathdutton
> **Originally opened:** 2026-01-02

---

## Summary

Removes the conflicting task instruction from `PROMPT_PREFIX` in the bulk-experimentation notebook.

## Motivation

The `PROMPT_PREFIX` contains `"You should return just the summary and nothing else."` but each prompt variation (e.g., `PROMPT_VARIATION_BASIC`) adds its own task instruction like `"You should return a summary that is concise and snappy."`. This creates overlapping/conflicting instructions when the prompts are combined.

Fixes #2337