### PR TITLE
docs: fix GPT-OSS vLLM install by removing expired PyTorch nightly

### DIFF
--- a/articles/gpt-oss/run-vllm.md
+++ b/articles/gpt-oss/run-vllm.md
@@ -20,19 +20,32 @@ Both models are **MXFP4 quantized** out of the box.
 
 ## Quick Setup
 
-1. **Install vLLM**  
-   vLLM recommends using [uv](https://docs.astral.sh/uv/) to manage your Python environment. This will help with picking the right implementation based on your environment. [Learn more in their quickstart](https://docs.vllm.ai/en/latest/getting_started/quickstart.html#installation). To create a new virtual environment and install vLLM run:
+> [!NOTE]
+> **Requirements**: Python 3.10–3.12 · CUDA 12.8 · NVIDIA driver ≥ 550 · GPU compute capability ≥ 8.0 (Ampere or newer)
+
+vLLM recommends using [uv](https://docs.astral.sh/uv/) to manage your Python environment.
 
 ```shell
+# Example shown for Python 3.12
 uv venv --python 3.12 --seed
 source .venv/bin/activate
-uv pip install --pre vllm==0.10.1+gptoss \
-    --extra-index-url https://wheels.vllm.ai/gpt-oss/ \
-    --extra-index-url https://download.pytorch.org/whl/nightly/cu128 \
-    --index-strategy unsafe-best-match
+
+# Install PyTorch 2.9.0 for CUDA 12.8 (stable wheel)
+uv pip install \
+  https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl
+
+# Install vLLM from GPT-OSS wheels
+uv pip install --pre "vllm==0.10.1+gptoss" \
+  --extra-index-url https://wheels.vllm.ai/gpt-oss/ \
+  --index-strategy unsafe-best-match
 ```
 
-2. **Start up a server and download the model**  
+> [!NOTE]
+> **Why stable PyTorch?** Previous versions of this guide referenced a PyTorch nightly build, which has since expired.
+> Installing the stable CUDA 12.8 PyTorch wheel separately avoids dependency resolution failures while remaining compatible
+> with current GPT-OSS vLLM wheels.
+
+**Start up a server and download the model**  
    vLLM provides a `serve` command that will automatically download the model from HuggingFace and spin up an OpenAI-compatible server on `localhost:8000`. Run the following command depending on your desired model size in a terminal session on your server.
 
 ```shell


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2334](https://github.com/openai/openai-cookbook/pull/2334)
> **Original author:** @sahiee-dev
> **Originally opened:** 2026-01-01

---

## Summary
Fix broken GPT-OSS vLLM installation instructions by replacing expired PyTorch nightly dependency with stable CUDA 12.8 wheel.
## Motivation
Fixes #2330
The Quick Setup section in [articles/gpt-oss/run-vllm.md](cci:7://file:///Users/lulu/Desktop/openai-cookbook/articles/gpt-oss/run-vllm.md:0:0-0:0) referenced a PyTorch nightly build (`torch==2.9.0.dev*`) that is no longer available from PyTorch's nightly index. This caused dependency resolution failures when users followed the installation instructions:
 No solution found when resolving dependencies:  Because there is no version of torch==2.9.0.dev20250804+cu128...

**This change:**
- Removes the nightly PyTorch dependency
- Installs stable PyTorch 2.9.0 (CUDA 12.8) via direct wheel URL
- Documents Python, CUDA, driver, and GPU requirements upfront
- Adds a rationale note explaining why stable PyTorch is used
**Verification:**
- PyTorch wheel URL confirmed available (HTTP 200, 900MB)
- vLLM GPT-OSS wheel index confirmed accessible
- Installation flow validated by community reports in #2330
- Full E2E verification requires CUDA hardware (not available on macOS)
---
## For new content
*Not applicable — this PR fixes existing documentation only. No new content is being added.*