### PR TITLE
docs: update Codex prompting guide to gpt-5.3-codex and refresh registry metadata

### DIFF
--- a/examples/gpt-5/codex_prompting_guide.ipynb
+++ b/examples/gpt-5/codex_prompting_guide.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Codex models advance the frontier of intelligence and efficiency and our recommended agentic coding model. Follow this guide closely to ensure you’re getting the best performance possible from this model. This guide is for anyone using the model directly via the API for maximum customizability; we also have the [Codex SDK](https://developers.openai.com/codex/sdk/) for simpler integrations.\n",
     "\n",
-    "In the API, the Codex-tuned model is `gpt-5.2-codex` (see the [model page](https://platform.openai.com/docs/models/gpt-5.2-codex)).\n",
+    "In the API, the Codex-tuned model is `gpt-5.3-codex` (see the [model page](https://developers.openai.com/api/docs/models/gpt-5.3-codex)).\n",
     "\n",
     "Recent improvements to Codex models\n",
     "\n",

--- a/registry.yaml
+++ b/registry.yaml
@@ -3023,9 +3023,10 @@
     - gpt-5-1-codex-max_prompting_guide
     - gpt-5-codex-prompting-guide
     - gpt-5-codex_prompting_guide
-  date: 2025-12-04
+  date: 2026-02-25
   authors:
     - nm-openai
+    - bfioca-openai
   tags:
     - codex
     - responses


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2466](https://github.com/openai/openai-cookbook/pull/2466)
> **Original author:** @ruth-openai
> **Originally opened:** 2026-02-25

---

### Motivation
- Update references to the Codex model to the new `gpt-5.3-codex` and refresh registry metadata to reflect the latest publish info.

### Description
- Updated `examples/gpt-5/codex_prompting_guide.ipynb` to reference `gpt-5.3-codex` and the corresponding docs URL, and updated `registry.yaml` entry for the Codex Prompting Guide to set the `date` to `2026-02-25` and add `bfioca-openai` to the `authors` list.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_699e98f0b66883298ad2e511f6677ba7)