### PR TITLE
Fix duplicate wording in GPT-Reatime-1.5 model description

### DIFF
--- a/examples/data/oai_docs/models.txt
+++ b/examples/data/oai_docs/models.txt
@@ -3,6 +3,8 @@
 
 ## Flagship models
 
+GPT-Reatime-1.5 is our flagship audio model for voice agents & customer support.
+
 
 
 ## Models overview


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2464](https://github.com/openai/openai-cookbook/pull/2464)
> **Original author:** @ruth-openai
> **Originally opened:** 2026-02-25

---

### Motivation
- Correct a small wording/duplication in the flagship models section so the `gpt-realtime` entry reads clearly and professionally.

### Description
- Update `examples/data/oai_docs/models.txt` to the single clarified sentence: `GPT-Reatime-1.5 is our flagship audio model for voice agents & customer support.`

### Testing
- Verified the change with `rg -n "GPT-Reatime-1.5|flagship audio model for voice agents" examples/data/oai_docs/models.txt` and confirmed the edit via `git diff` and a successful `git commit` with the message `Fix duplicated word in GPT-Reatime-1.5 description`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_699e4f04ccdc83298ee28e8116ac740f)