### PR TITLE
Add Skills docs links to Skills in OpenAI API notebook

### DIFF
--- a/examples/skills_in_api.ipynb
+++ b/examples/skills_in_api.ipynb
@@ -11,7 +11,7 @@
    "source": [
     "# Skills in OpenAI API\n",
     "\n",
-    "Upload, manage, and attach reusable skills to hosted environments. Agent Skills let you upload and reuse versioned bundles of files in hosted and local shell environments."
+    "Upload, manage, and attach reusable skills to hosted environments. Agent Skills let you upload and reuse versioned bundles of files in hosted and local shell environments. For the full reference, see the [Skills documentation](https://developers.openai.com/api/docs/guides/tools-skills)."
    ]
   },
   {
@@ -716,7 +716,9 @@
     "\n",
     "**Use skills to keep your system prompts lean and your workflows durable.** Start small—bundle one stable procedure with a clear `SKILL.md`, make it runnable as a tiny CLI, and ship it. After it’s in production, pin versions for reproducibility, iterate safely by publishing new versions, and treat your skills library like an internal standard library: audited, discoverable, and shared across agents.\n",
     "\n",
-    "As users scale from single-turn assistants to long-running agents, skills help turn “prompt spaghetti” into **maintainable, testable, versioned workflows**—for building agentic behavior you can trust, reuse, and evolve over time."
+    "As users scale from single-turn assistants to long-running agents, skills help turn “prompt spaghetti” into **maintainable, testable, versioned workflows**—for building agentic behavior you can trust, reuse, and evolve over time.\n",
+    "\n",
+    "To get started with Skills, check out our [documentation](https://developers.openai.com/api/docs/guides/tools-skills)."
    ]
   }
  ],


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2430](https://github.com/openai/openai-cookbook/pull/2430)
> **Original author:** @cguo-oai
> **Originally opened:** 2026-02-10

---

## Summary
- Add a link to the Skills docs page in the opening paragraph of `examples/skills_in_api.ipynb`
- Add a second link in the conclusion with a clear getting-started callout

## Motivation
- Make it easier for readers of the notebook to find the canonical Skills documentation for setup and deeper reference details.

---

## For new content
- [ ] N/A (this PR updates an existing notebook and does not add new content files)
