### PR TITLE
Move web research prompt guidance to appendix

### DIFF
--- a/examples/gpt-5/gpt-5-2_prompting_guide.ipynb
+++ b/examples/gpt-5/gpt-5-2_prompting_guide.ipynb
@@ -396,8 +396,26 @@
     "- Write clearly and directly using Markdown (headers, bullets, tables when helpful); define acronyms, use concrete examples, and keep a natural, conversational tone.\n",
     "</web_search_rules>\n",
     "```\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb16d1b9",
+   "metadata": {},
+   "source": [
+    "## 10. Conclusion  \n",
     "\n",
-    "Optionally you can provide more detailed guidance as follows: \n",
+    "GPT-5.2 represents a meaningful step forward for teams building production-grade agents that prioritize accuracy, reliability, and disciplined execution. It delivers stronger instruction following, cleaner output, and more consistent behavior across complex, tool-heavy workflows. Most existing prompts migrate cleanly, especially when reasoning effort, verbosity, and scope constraints are preserved during the initial transition. Teams should rely on evals to validate behavior before making prompt changes, adjusting reasoning effort or constraints only when regressions appear. With explicit prompting and measured iteration, GPT-5.2 can unlock higher quality outcomes while maintaining predictable cost and latency profiles."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Appendix\n",
+    "\n",
+    "### Example prompt for a web research agent:\n",
     "```\n",
     "You are a helpful, warm web research agent. Your job is to deeply and thoroughly research the web and provide long, detailed, comprehensive, well written, and well structured answers grounded in reliable sources. Your answers should be engaging, informative, concrete, and approachable. You MUST adhere perfectly to the guidelines below.\n",
     "############################################\n",
@@ -496,16 +514,6 @@
     "First deliver what you can (safe partial answers, verified material, or a closely related helpful alternative), then clearly state any limitations (policy limits, missing/behind-paywall data, unverifiable claims).\n",
     "If something cannot be verified, say so plainly, explain what you did verify, what remains unknown, and the best next step to resolve it (without asking the user a question).\n",
     "```\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bb16d1b9",
-   "metadata": {},
-   "source": [
-    "## 10. Conclusion  \n",
-    "\n",
-    "GPT-5.2 represents a meaningful step forward for teams building production-grade agents that prioritize accuracy, reliability, and disciplined execution. It delivers stronger instruction following, cleaner output, and more consistent behavior across complex, tool-heavy workflows. Most existing prompts migrate cleanly, especially when reasoning effort, verbosity, and scope constraints are preserved during the initial transition. Teams should rely on evals to validate behavior before making prompt changes, adjusting reasoning effort or constraints only when regressions appear. With explicit prompting and measured iteration, GPT-5.2 can unlock higher quality outcomes while maintaining predictable cost and latency profiles."
    ]
   }
  ],


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2290](https://github.com/openai/openai-cookbook/pull/2290)
> **Original author:** @dmitry-openai
> **Originally opened:** 2025-12-12

---

## Summary
- Move the detailed web research agent prompt from section 9 into a new appendix after the conclusion.
- Add an appendix subtitle labeling the prompt as an example for a web research agent.
- Keep the main web search guidance focused on best practices while retaining the full prompt as supporting material.

## Motivation
- Improve readability by keeping the main guidance concise and relocating the lengthy prompt to a clearly labeled appendix.

---

## For new content
- [x] I have added a new entry in [registry.yaml](https://github.com/openai/openai-cookbook/blob/main/registry.yaml) (and, optionally, in [authors.yaml](https://github.com/openai/openai-cookbook/blob/main/authors.yaml)) so that my content renders on the cookbook website. (N/A – existing notebook already registered)
- [x] I have conducted a self-review of my content based on the [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md#rubric):
  - [x] Relevance: This content is related to building with OpenAI technologies and is useful to others.
  - [x] Uniqueness: I have searched for related examples in the OpenAI Cookbook, and verified that my content offers new insights or unique information compared to existing documentation.
  - [x] Spelling and Grammar: I have checked for spelling or grammatical mistakes.
  - [x] Clarity: I have done a final read-through and verified that my submission is well-organized and easy to understand.
  - [x] Correctness: The information I include is correct and all of my code executes successfully.
  - [x] Completeness: I have explained everything fully, including all necessary references and citations.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_693b852fd19c832485a681996ef4b363)
