### PR TITLE
Fix misleading summary description in session_memory.ipynb

### DIFF
--- a/examples/agents_sdk/session_memory.ipynb
+++ b/examples/agents_sdk/session_memory.ipynb
@@ -1146,7 +1146,7 @@
     "await session.add_items([{\"role\": \"assistant\", \"content\": \"Can you please provide me with the error code?\"}])\n",
     "await session.add_items([{\"role\": \"user\", \"content\": \"It says 404 not found when I try to access the page.\"}])\n",
     "await session.add_items([{\"role\": \"assistant\", \"content\": \"Are you connected to the internet?\"}])\n",
-    "# At this point, with context_limit=4, everything *before* the earliest of the last 4 turns\n",
+    "# At this point, with context_limit=4, everything *before* the earliest of the last 2 turns\n",
     "# is summarized into a synthetic pair, and the last 2 turns remain verbatim.\n"
    ]
   },


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2267](https://github.com/openai/openai-cookbook/pull/2267)
> **Original author:** @Yuyutsu01
> **Originally opened:** 2025-12-01

---

This PR updates the explanation of how conversation history is summarized in session_memory.ipynb.
The previous wording suggested the earliest of the last 4 turns is summarized, but the implementation actually keeps the last 2 turns verbatim and summarizes earlier messages.
This corrects the text to match the code behavior.

