### PR TITLE
Fix typo in Codex execution plans documentation

### DIFF
--- a/articles/codex_exec_plans.md
+++ b/articles/codex_exec_plans.md
@@ -4,7 +4,7 @@ Codex and the `gpt-5-codex` model can be used to implement complex tasks that ta
 
 These plans are thorough design documents, and "living documents". As a user of Codex, you can use these documents to verify the approach that Codex will take before it begins a long implementation process. The particular `PLANS.md` included below is very similar to one that has enabled Codex to work for more than seven hours from a single prompt.
 
-We enable Codex to use these documemnts by first updating `AGENTS.md` to describe when to use `PLANS.md`, and then of course, to add the `PLANS.md` file to our repository.
+We enable Codex to use these documents by first updating `AGENTS.md` to describe when to use `PLANS.md`, and then of course, to add the `PLANS.md` file to our repository.
 
 ## `AGENTS.md`
 


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2200](https://github.com/openai/openai-cookbook/pull/2200)
> **Original author:** @simonepizzamiglio
> **Originally opened:** 2025-10-21

---

## Summary

Fix minor typo in Codex execution plans documentation.
