### PR TITLE
Fix outdated link in libraries.txt for JuliaML

### DIFF
--- a/examples/data/oai_docs/libraries.txt
+++ b/examples/data/oai_docs/libraries.txt
@@ -139,7 +139,7 @@ Please note that OpenAI does not verify the correctness or security of these pro
 
 ### Julia
 
--   [OpenAI.jl](https://github.com/rory-linehan/OpenAI.jl) by [rory-linehan](https://github.com/rory-linehan)
+-   [OpenAI.jl](https://github.com/JuliaML/OpenAI.jl) by [the JuliaML community](https://github.com/JuliaML)
 
 ### Kotlin
 


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2199](https://github.com/openai/openai-cookbook/pull/2199)
> **Original author:** @hintz-openai
> **Originally opened:** 2025-10-21

---

## Summary

update outdated link to the JuliaML community library

## Motivation

The old link is pointing to an outdated location.

Thanks to nvk0x for suggesting this fix!
