### PR TITLE
Specify recipient of tool response in harmony example

### DIFF
--- a/articles/openai-harmony.md
+++ b/articles/openai-harmony.md
@@ -100,7 +100,9 @@ convo = Conversation.from_messages(
         Message.from_author_and_content(
             Author.new(Role.TOOL, "functions.get_current_weather"),
             '{ "temperature": 20, "sunny": true }',
-        ).with_channel("commentary"),
+        )
+        .with_channel("commentary")
+        .with_recipient("assistant"),
     ]
 )
 


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2131](https://github.com/openai/openai-cookbook/pull/2131)
> **Original author:** @Joshua-Chin
> **Originally opened:** 2025-09-11

---

## Summary

This PR specifies the assistant as the recipient of the tool message in the OpenAI Harmony code example.

## Motivation

Under the __Handling tool calls__ section, it states that: 

> A tool message has the following format:
> 
> ```<|start|>{toolname} to=assistant<|channel|>commentary<|message|>{output}<|end|>```
> 
> So in our example above
> 
> ```<|start|>functions.get_current_weather to=assistant<|channel|>commentary<|message|>{"sunny": true, "temperature": 20}<|end|>```

The code in its current state does not include the `to=assistant` text section.
