### PR TITLE
Fix typo in GPT-5 prompting guide regarding API features

### DIFF
--- a/examples/gpt-5/gpt-5_prompting_guide.ipynb
+++ b/examples/gpt-5/gpt-5_prompting_guide.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "GPT-5, our newest flagship model, represents a substantial leap forward in agentic task performance, coding, raw intelligence, and steerability.\n",
     "\n",
-    "While we trust it will perform excellently “out of the box” across a wide range of domains, in this guide we’ll cover prompting tips to maximize the quality of model outputs, derived from our experience training and applying the model to real-world tasks. We discuss concepts like improving agentic task performance, ensuring instruction adherence, making use of newly API features, and optimizing coding for frontend and software engineering tasks - with key insights into AI code editor Cursor’s prompt tuning work with GPT-5.\n",
+    "While we trust it will perform excellently “out of the box” across a wide range of domains, in this guide we’ll cover prompting tips to maximize the quality of model outputs, derived from our experience training and applying the model to real-world tasks. We discuss concepts like improving agentic task performance, ensuring instruction adherence, making use of new API features, and optimizing coding for frontend and software engineering tasks - with key insights into AI code editor Cursor’s prompt tuning work with GPT-5.\n",
     "\n",
     "We’ve seen significant gains from applying these best practices and adopting our canonical tools whenever possible, and we hope that this guide, along with the [prompt optimizer tool](https://platform.openai.com/chat/edit?optimize=true) we’ve built, will serve as a launchpad for your use of GPT-5. But, as always, remember that prompting is not a one-size-fits-all exercise - we encourage you to run experiments and iterate on the foundation offered here to find the best solution for your problem."
    ]


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2106](https://github.com/openai/openai-cookbook/pull/2106)
> **Original author:** @joelklabo
> **Originally opened:** 2025-09-02

---

## Summary

Fix typo `Newly` -> `New` in ChatGPT-5 Prompting Guide.
