### PR TITLE
Update prompt-optimization-cookbook.ipynb

### DIFF
--- a/examples/gpt-5/prompt-optimization-cookbook.ipynb
+++ b/examples/gpt-5/prompt-optimization-cookbook.ipynb
@@ -953,7 +953,7 @@
    "id": "0a84939c",
    "metadata": {},
    "source": [
-    "GPT-5-mini crushes this task, so even the baseline prompt gets scores of >= 4 almost all of the time. However if we compare the percent of perfect scores (6/6) for the judge, we see that the optimize prompt has way significantly more perfect answers when evaluated in the two categories of FailSafeQA answer quality: robustness and context grounding."
+    "GPT-5-mini crushes this task, so even the baseline prompt gets scores of >= 4 almost all of the time. However, if we compare the percent of perfect scores (6/6) for the judge, we see that the optimized prompt has way more perfect answers when evaluated in the two categories of FailSafeQA answer quality: robustness and context grounding."
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2104](https://github.com/openai/openai-cookbook/pull/2104)
> **Original author:** @nastyaOsh
> **Originally opened:** 2025-09-01

---

Just some spelling and punctuation corrections

## Summary

Just a couple of spelling and punctuation correction for the GPT-5 prompt optimizer article.

## Motivation

Improve the legibility of the article.

---

## For new content

When contributing new content, read through our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md), and mark the following action items as completed:

- [ ] I have added a new entry in [registry.yaml](https://github.com/openai/openai-cookbook/blob/main/registry.yaml) (and, optionally, in [authors.yaml](https://github.com/openai/openai-cookbook/blob/main/authors.yaml)) so that my content renders on the cookbook website.
- [ ] I have conducted a self-review of my content based on the [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md#rubric):
  - [ ] Relevance: This content is related to building with OpenAI technologies and is useful to others.
  - [ ] Uniqueness: I have searched for related examples in the OpenAI Cookbook, and verified that my content offers new insights or unique information compared to existing documentation.
  - [ ] Spelling and Grammar: I have checked for spelling or grammatical mistakes.
  - [ ] Clarity: I have done a final read-through and verified that my submission is well-organized and easy to understand.
  - [ ] Correctness: The information I include is correct and all of my code executes successfully.
  - [ ] Completeness: I have explained everything fully, including all necessary references and citations.

We will rate each of these areas on a scale from 1 to 4, and will only accept contributions that score 3 or higher on all areas. Refer to our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md) for more details.
