### PR TITLE
Update transformers to avoid triton errors.

### DIFF
--- a/articles/gpt-oss/run-colab.ipynb
+++ b/articles/gpt-oss/run-colab.ipynb
@@ -65,7 +65,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -q git+https://github.com/huggingface/transformers triton==3.4 kernels"
+        "!pip install -q transformers triton==3.4 kernels"
       ]
     },
     {

--- a/articles/gpt-oss/run-transformers.md
+++ b/articles/gpt-oss/run-transformers.md
@@ -29,11 +29,7 @@ If you use `bfloat16` instead of MXFP4, memory consumption will be larger (\~48 
    It’s recommended to create a fresh Python environment. Install transformers, accelerate, as well as the Triton kernels for MXFP4 compatibility:
 
 ```bash
-pip install -U transformers accelerate torch triton kernels
-```
-
-```bash
-pip install git+https://github.com/triton-lang/triton.git@main#subdirectory=python/triton_kernels
+pip install -U transformers accelerate torch triton==3.4 kernels
 ```
 
 2. **(Optional) Enable multi-GPU**  


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2051](https://github.com/openai/openai-cookbook/pull/2051)
> **Original author:** @Vaibhavs10
> **Originally opened:** 2025-08-12

---

## Summary

The PR updates both the `Run in Colab` as well as the `gpt-oss` transformers cookbook to work with the latest transformers release (this will be released tomorrow): https://github.com/huggingface/transformers/releases

The PR will ensure that users do not depend on the bleeding edge of triton kernels like here: https://github.com/triton-lang/triton/issues/7818

## Motivation

Makes it easier and less error prone to run `gpt-oss` models with Transformers. 🤗
