### PR TITLE
chore: fix typo in gpt-5_new_params_and_tools.ipynb

### DIFF
--- a/examples/gpt-5/gpt-5_new_params_and_tools.ipynb
+++ b/examples/gpt-5/gpt-5_new_params_and_tools.ipynb
@@ -503,7 +503,7 @@
    "id": "fa48bbeb",
    "metadata": {},
    "source": [
-    "Medium verboisty, generated richer code with additioanl explanations. Let's do the same with high. "
+    "Medium verboisty, generated richer code with additional explanations. Let's do the same with high."
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2035](https://github.com/openai/openai-cookbook/pull/2035)
> **Original author:** @dr-frmr
> **Originally opened:** 2025-08-08

---

## Summary

Fix a typo in GPT-5 examples
