### PR TITLE
Fix Missing imports in openai-harmony.md example code

### DIFF
--- a/articles/openai-harmony.md
+++ b/articles/openai-harmony.md
@@ -126,18 +126,20 @@ Additionally the openai_harmony library also includes a StreamableParser for par
 ```py
 from openai_harmony import (
     load_harmony_encoding,
-    StreamableParser
+    Role,
+    StreamableParser,
+    HarmonyEncodingName
 )
-
+ 
 encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
 stream = StreamableParser(encoding, role=Role.ASSISTANT)
-
+ 
 tokens = [
     200005,35644,200008,1844,31064,25,392,4827,382,220,17,659,220,17,16842,12295,81645,
     13,51441,6052,13,200007,200006,173781,200005,17196,200008,17,659,220,17,314,220,19,
     13,200002
 ]
-
+ 
 for token in tokens:
     stream.process(token)
     print("--------------------------------")

--- a/articles/openai-harmony.md
+++ b/articles/openai-harmony.md
@@ -130,16 +130,16 @@ from openai_harmony import (
     StreamableParser,
     HarmonyEncodingName
 )
- 
+
 encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
 stream = StreamableParser(encoding, role=Role.ASSISTANT)
- 
+
 tokens = [
     200005,35644,200008,1844,31064,25,392,4827,382,220,17,659,220,17,16842,12295,81645,
     13,51441,6052,13,200007,200006,173781,200005,17196,200008,17,659,220,17,314,220,19,
     13,200002
 ]
- 
+
 for token in tokens:
     stream.process(token)
     print("--------------------------------")


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2010](https://github.com/openai/openai-cookbook/pull/2010)
> **Original author:** @Howe829
> **Originally opened:** 2025-08-07

---

## Summary

Add some missing imports in openai-harmony.md

## Motivation

Why are these changes necessary? How do they improve the cookbook?
Make sure the example code run normally.
---

## For new content

When contributing new content, read through our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md), and mark the following action items as completed:

- [ ] I have added a new entry in [registry.yaml](https://github.com/openai/openai-cookbook/blob/main/registry.yaml) (and, optionally, in [authors.yaml](https://github.com/openai/openai-cookbook/blob/main/authors.yaml)) so that my content renders on the cookbook website.
- [ ] I have conducted a self-review of my content based on the [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md#rubric):
  - [ ] Relevance: This content is related to building with OpenAI technologies and is useful to others.
  - [x] Uniqueness: I have searched for related examples in the OpenAI Cookbook, and verified that my content offers new insights or unique information compared to existing documentation.
  - [x] Spelling and Grammar: I have checked for spelling or grammatical mistakes.
  - [x] Clarity: I have done a final read-through and verified that my submission is well-organized and easy to understand.
  - [x] Correctness: The information I include is correct and all of my code executes successfully.
  - [x] Completeness: I have explained everything fully, including all necessary references and citations.

We will rate each of these areas on a scale from 1 to 4, and will only accept contributions that score 3 or higher on all areas. Refer to our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md) for more details.
