### PR TITLE
Fix SyntaxError: unmatched ')' in openai-harmony.md example code

### DIFF
--- a/articles/openai-harmony.md
+++ b/articles/openai-harmony.md
@@ -91,7 +91,6 @@ developer_message = (
                 ),
             ]
         )
-	)
 )
 
 convo = Conversation.from_messages(


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#2007](https://github.com/openai/openai-cookbook/pull/2007)
> **Original author:** @DIYer22
> **Originally opened:** 2025-08-07

---

## Summary
Example code in `openai-harmony.md` has mismatched parentheses.

