### PR TITLE
Nits in "Fine-tuning a Multilingual Reasoner with Hugging Face" recipe

### DIFF
--- a/articles/gpt-oss/fine-tune-transfomers.ipynb
+++ b/articles/gpt-oss/fine-tune-transfomers.ipynb
@@ -190,10 +190,10 @@
       "source": [
         "|||\n",
         "| :---- | :--|\n",
-        "| `developer` | The developer message is used to provide custom instructions for the model (what we usually call the `system` role) |\n",
-        "| `user` | The user message is used to provide the input to the model |\n",
+        "| `developer` | The developer message is used to provide custom instructions for the model (what we usually call the `system` role). |\n",
+        "| `user` | The user message is used to provide the input to the model. |\n",
         "| `assistant` | Output by the model which can either be a tool call or a message output. The output might also be associated with a particular “channel” identifying what the intent of the message is. |\n",
-        "| `analysis` | These are messages that are being used by the model for its chain-of thought |\n",
+        "| `analysis` | These are messages that are being used by the model for its chain-of-thought |\n",
         "| `final` | Messages tagged in the final channel are messages intended to be shown to the end-user and represent the responses from the model. |\n",
         "| `messages` | The list of messages that combine the content of the above to produce a full conversation. This is the input to the model. |"
       ]
@@ -345,7 +345,7 @@
         "\n",
         "To do so, we will use a technique called [LoRA](https://huggingface.co/learn/llm-course/chapter11/4) (Low-Rank Adaptation) to fine-tune the model. This technique allows us to tune a few specific layers of the model, which is particularly useful for large models like `openai/gpt-oss-20b`.\n",
         "\n",
-        "First we need wrap the model as a `PeftModel` and define the LoRA configuration. We will use the `LoraConfig` class from the [PEFT library](https://github.com/huggingface/peft) to do this:"
+        "First we need to wrap the model as a `PeftModel` and define the LoRA configuration. We will use the `LoraConfig` class from the [PEFT library](https://github.com/huggingface/peft) to do this:"
       ]
     },
     {
@@ -604,7 +604,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "\n",
         "REASONING_LANGUAGE = \"Chinese\"  # or Hindi, or any other language...\n",
         "SYSTEM_PROMPT = f\"reasoning language: {REASONING_LANGUAGE}\"\n",
         "USER_PROMPT = \"What is the national symbol of Canada?\"\n",


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1999](https://github.com/openai/openai-cookbook/pull/1999)
> **Original author:** @sergiopaniego
> **Originally opened:** 2025-08-06

---

## Summary

Corrected some typos and punctuation in the HF + TRL recipe.

## Motivation

Why are these changes necessary? How do they improve the cookbook?

---

## For new content

When contributing new content, read through our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md), and mark the following action items as completed:

- [ ] I have added a new entry in [registry.yaml](https://github.com/openai/openai-cookbook/blob/main/registry.yaml) (and, optionally, in [authors.yaml](https://github.com/openai/openai-cookbook/blob/main/authors.yaml)) so that my content renders on the cookbook website.
- [ ] I have conducted a self-review of my content based on the [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md#rubric):
  - [ ] Relevance: This content is related to building with OpenAI technologies and is useful to others.
  - [ ] Uniqueness: I have searched for related examples in the OpenAI Cookbook, and verified that my content offers new insights or unique information compared to existing documentation.
  - [ ] Spelling and Grammar: I have checked for spelling or grammatical mistakes.
  - [ ] Clarity: I have done a final read-through and verified that my submission is well-organized and easy to understand.
  - [ ] Correctness: The information I include is correct and all of my code executes successfully.
  - [ ] Completeness: I have explained everything fully, including all necessary references and citations.

We will rate each of these areas on a scale from 1 to 4, and will only accept contributions that score 3 or higher on all areas. Refer to our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md) for more details.
