### PR TITLE
Small typo in run-vllm.md

### DIFF
--- a/articles/gpt-oss/run-vllm.md
+++ b/articles/gpt-oss/run-vllm.md
@@ -197,7 +197,7 @@ convo = Conversation.from_messages(
 prefill_ids = encoding.render_conversation_for_completion(convo, Role.ASSISTANT)
 
 # Harmony stop tokens (pass to sampler so they won't be included in output)
-stop_token_ids = encoding.stop_tokens_for_assistant_action()
+stop_token_ids = encoding.stop_tokens_for_assistant_actions()
 
 # --- 2) Run vLLM with prefill ---
 llm = LLM(


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1986](https://github.com/openai/openai-cookbook/pull/1986)
> **Original author:** @sethkimmel3
> **Originally opened:** 2025-08-05

---

## Summary

Fixes a small typo in the code to run the gpt-oss models in vllm. 

## Motivation

`stop_token_ids = encoding.stop_tokens_for_assistant_action()`

should be

`stop_token_ids = encoding.stop_tokens_for_assistant_actions()` 

Confirmed here: https://github.com/openai/harmony/blob/eeece1861c65c6f60ff072fd110103abb037fb62/python/openai_harmony/__init__.py#L594
