### PR TITLE
Correct Harmony example developer message

### DIFF
--- a/articles/openai-harmony.md
+++ b/articles/openai-harmony.md
@@ -97,7 +97,7 @@ developer_message = (
 convo = Conversation.from_messages(
     [
         Message.from_role_and_content(Role.SYSTEM, system_message),
-        Message.from_role_and_content(Role.DEVELOPER, system_message),
+        Message.from_role_and_content(Role.DEVELOPER, developer_message),
         Message.from_role_and_content(Role.USER, "What is the weather in Tokyo?"),
         Message.from_role_and_content(
             Role.ASSISTANT,


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1984](https://github.com/openai/openai-cookbook/pull/1984)
> **Original author:** @geoffhill
> **Originally opened:** 2025-08-05

---

This pull request fixes a (copy-paste?) bug which uses the system message as the developer message.
