### PR TITLE
Update Image Evals Cookbook w/ Logs info

### DIFF
--- a/examples/evaluation/use-cases/EvalsAPI_Image_Inputs.ipynb
+++ b/examples/evaluation/use-cases/EvalsAPI_Image_Inputs.ipynb
@@ -245,7 +245,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To create the run, we pass in the eval object id, the data source (i.e., the data we compiled earlier), and the chat message input we will use for sampling to generate the model response. While we won't dive into it in this cookbook, EvalsAPI also supports stored completions containing images as a data source. \n",
+    "To create the run, we pass in the eval object id, the data source (i.e., the data we compiled earlier), and the chat message input we will use for sampling to generate the model response. Note that EvalsAPI also supports stored completions and responses containing images as a data source. See the [Additional Info: Logs Data Source](#additional-info-logs-data-source) section for more info.\n",
     "\n",
     "Here's the sampling message input we'll use for this example."
    ]
@@ -507,6 +507,22 @@
     "first_item = output_items[0]\n",
     "\n",
     "print(json.dumps(dict(first_item), indent=2, default=str))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Additional Info: Logs Data Source\n",
+    "\n",
+    "As mentioned earlier, EvalsAPI supports logs (i.e., stored completions or responses) containing images as a data source. To use this functionality, change your eval configurations as follows: \n",
+    "\n",
+    "Eval Creation\n",
+    "  - set `data_source_config = { \"type\": \"logs\" }`\n",
+    "  - revise templating in `grader_config` to use `{{item.input}}` and/or `{{sample.output_text}}`, denoting the input and output of the log\n",
+    "\n",
+    "Eval Run Creation\n",
+    "  - set the `data_source` to specify the filters to use to obtain your logs for the eval run (see the [docs](https://platform.openai.com/docs/api-reference/evals/createRun) for more information)"
    ]
   },
   {

--- a/examples/evaluation/use-cases/EvalsAPI_Image_Inputs.ipynb
+++ b/examples/evaluation/use-cases/EvalsAPI_Image_Inputs.ipynb
@@ -522,7 +522,7 @@
     "  - revise templating in `grader_config` to use `{{item.input}}` and/or `{{sample.output_text}}`, denoting the input and output of the log\n",
     "\n",
     "Eval Run Creation\n",
-    "  - set the `data_source` to specify the filters to use to obtain your logs for the eval run (see the [docs](https://platform.openai.com/docs/api-reference/evals/createRun) for more information)"
+    "  - specify the filters in the `data_source` field that will be used to obtain the corresponding logs for the eval run (see the [docs](https://platform.openai.com/docs/api-reference/evals/createRun) for more information)"
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1981](https://github.com/openai/openai-cookbook/pull/1981)
> **Original author:** @daisyshe-oai
> **Originally opened:** 2025-08-04

---

## Summary

See title.

## Motivation

Logs containing images are able to be supported within EvalsAPI, both for stored completions (relatively new!) and responses, so added a section in the existing cookbook to highlight this functionality to users. 
