### PR TITLE
Adding new encoding description for gpt-4.1 and gpt-4.5 models

### DIFF
--- a/examples/How_to_count_tokens_with_tiktoken.ipynb
+++ b/examples/How_to_count_tokens_with_tiktoken.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "| Encoding name           | OpenAI models                                       |\n",
     "|-------------------------|-----------------------------------------------------|\n",
-    "| `o200k_base`            | `gpt-4o`, `gpt-4o-mini`                             |\n",
+    "| `o200k_base`            | `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4.5-preview`, `gpt-4.5`                             |\n",
     "| `cl100k_base`           | `gpt-4-turbo`, `gpt-4`, `gpt-3.5-turbo`, `text-embedding-ada-002`, `text-embedding-3-small`, `text-embedding-3-large`  |\n",
     "| `p50k_base`             | Codex models, `text-davinci-002`, `text-davinci-003`|\n",
     "| `r50k_base` (or `gpt2`) | GPT-3 models like `davinci`                         |\n",


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1966](https://github.com/openai/openai-cookbook/pull/1966)
> **Original author:** @kuzminT
> **Originally opened:** 2025-07-20

---

* Added encoding for new gpt-4.1 and gpt-4.5 models in the tokenizer guide. All they use the same o200k_base tokenizer.
