### PR TITLE
Small link correction to rft healthbench cookbook

### DIFF
--- a/examples/fine-tuned_qa/reinforcement_finetuning_healthbench.ipynb
+++ b/examples/fine-tuned_qa/reinforcement_finetuning_healthbench.ipynb
@@ -36,7 +36,7 @@
     "1. Clone the simple-evals repo\n",
     "\n",
     "```bash\n",
-    "git clone https://github.com/roberttinn/simple-eval.git\n",
+    "git clone https://github.com/openai/simple-evals.git\n",
     "pip install openai human-eval\n",
     "```\n",
     "\n",


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1896](https://github.com/openai/openai-cookbook/pull/1896)
> **Original author:** @robtinn
> **Originally opened:** 2025-06-12

---

## Summary

Small fix: update instruction to correct link
