### PR TITLE
fix typo in custom image embedding example

### DIFF
--- a/examples/custom_image_embedding_search.ipynb
+++ b/examples/custom_image_embedding_search.ipynb
@@ -438,7 +438,7 @@
         "id": "0O-GYQ-1QAqm"
       },
       "source": [
-        "We require the indices as we will use this to serach through our image_directory and selecting the image at the location of the index to feed into the vision model for RAG."
+        "We require the indices as we will use this to search through our image_directory and selecting the image at the location of the index to feed into the vision model for RAG."
       ]
     },
     {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1856](https://github.com/openai/openai-cookbook/pull/1856)
> **Original author:** @collingreen
> **Originally opened:** 2025-05-27

---


## Summary

Fix a small typo in the custom image embedding example text - s/serach/search

## Motivation

Tiny cleanup of a misspelled word.

---

This should not count as new content - not adding anything to the registry nor adding to the authors list.
