### PR TITLE
Typo fix on multi language article name

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -1859,7 +1859,7 @@
     - responses
     - speech
 
-- title: Multi-Langugage One-Way Translation with the Realtime API
+- title: Multi-Language One-Way Translation with the Realtime API
   path: examples/voice_solutions/one_way_translation_using_realtime_api.mdx
   date: 2025-03-24
   authors:


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1755](https://github.com/openai/openai-cookbook/pull/1755)
> **Original author:** @rupert-openai
> **Originally opened:** 2025-03-31

---

Typo fix on title
