### PR TITLE
Add missing pandas package install to cookbook Outfit Assistant

### DIFF
--- a/examples/How_to_combine_GPT4o_with_RAG_Outfit_Assistant.ipynb
+++ b/examples/How_to_combine_GPT4o_with_RAG_Outfit_Assistant.ipynb
@@ -47,7 +47,8 @@
     "%pip install numpy --quiet\n",
     "%pip install typing --quiet\n",
     "%pip install tiktoken --quiet\n",
-    "%pip install concurrent --quiet"
+    "%pip install concurrent --quiet\n",
+    "%pip install pandas --quiet"
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1695](https://github.com/openai/openai-cookbook/pull/1695)
> **Original author:** @mshahat
> **Originally opened:** 2025-02-23

---

## Summary

Add a missing package install, pandas.

## Motivation

Make it easier for new starters to run the cookbook notebook.

---
