### PR TITLE
Fix broken link in how to use guardrails doc

### DIFF
--- a/examples/How_to_use_guardrails.ipynb
+++ b/examples/How_to_use_guardrails.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "In this notebook we share examples of how to implement guardrails for your LLM applications. A guardrail is a generic term for **detective controls** that aim to steer your application. Greater steerability is a common requirement given the inherent randomness of LLMs, and so creating effective guardrails has become one of the most common areas of performance optimization when pushing an LLM from prototype to production. \n",
     "\n",
-    "Guardrails are incredibly [diverse](https://github.com/NVIDIA/NeMo-Guardrails/blob/main/examples/README.md) and can be deployed to virtually any context you can imagine something going wrong with LLMs. This notebook aims to give simple examples that can be extended to meet your unique use case, as well as outlining the trade-offs to consider when deciding whether to implement a guardrail, and how to do it.\n",
+    "Guardrails are incredibly [diverse](https://github.com/NVIDIA/NeMo-Guardrails/blob/25e877831b385f8b15c3f3d4f7793f2b85a64932/examples/README.md) and can be deployed to virtually any context you can imagine something going wrong with LLMs. This notebook aims to give simple examples that can be extended to meet your unique use case, as well as outlining the trade-offs to consider when deciding whether to implement a guardrail, and how to do it.\n",
     "\n",
     "This notebook will focus on:\n",
     "1. **Input guardrails** that flag inappropriate content before it gets to your LLM\n",


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1606](https://github.com/openai/openai-cookbook/pull/1606)
> **Original author:** @RiccardoBiosas
> **Originally opened:** 2024-12-19

---

## Summary

The [how-to-use-guardrails](https://cookbook.openai.com/examples/how_to_use_guardrails) tutorial refers to a NVIDIA NeMo README.md that was deleted in [this commit](https://github.com/NVIDIA/NeMo-Guardrails/commit/b661ab11c8a58b7b0aab4f0935e84c0f022a944c#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9). This PR replaces the broken link with the last working README commit before its deletion.

## Motivation

Keep the references readable and up-to-date.

