### PR TITLE
Missing word in "How to call functions with chat models"

### DIFF
--- a/examples/How_to_call_functions_with_chat_models.ipynb
+++ b/examples/How_to_call_functions_with_chat_models.ipynb
@@ -648,7 +648,7 @@
    "id": "77e6e5ea",
    "metadata": {},
    "source": [
-    "Now can use these utility functions to extract a representation of the database schema."
+    "Now we can use these utility functions to extract a representation of the database schema."
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1600](https://github.com/openai/openai-cookbook/pull/1600)
> **Original author:** @LaurentAjdnik
> **Originally opened:** 2024-12-10

---

## Summary

Adds a missing word in a sentence.

## Motivation

A word is missing in [this section](https://cookbook.openai.com/examples/how_to_call_functions_with_chat_models#specifying-a-function-to-execute-sql-queries).

"Now can use these utility functions to extract a representation of the database schema." => "Now **we** can use these utility functions to extract a representation of the database schema."
