### PR TITLE
typo: change implitly to implicitly in code comment

### DIFF
--- a/examples/Orchestrating_agents.ipynb
+++ b/examples/Orchestrating_agents.ipynb
@@ -575,7 +575,7 @@
     "messages.extend(response)\n",
     "\n",
     "\n",
-    "user_query = \"Actually, I want a refund.\" # implitly refers to the last item\n",
+    "user_query = \"Actually, I want a refund.\" # implicitly refers to the last item\n",
     "print(\"User:\", user_query)\n",
     "messages.append({\"role\": \"user\", \"content\": user_query})\n",
     "response = run_full_turn(refund_agent, messages) # refund agent"


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1597](https://github.com/openai/openai-cookbook/pull/1597)
> **Original author:** @jonathanmv
> **Originally opened:** 2024-12-07

---

## Summary

fix "implitly" typo in code comment

## Motivation

Grammar correctness
