### PR TITLE
Add O1 streaming examples

### DIFF
--- a/examples/o1/streaming_with_o1.py
+++ b/examples/o1/streaming_with_o1.py
@@ -20,11 +20,11 @@ def basic_streaming_example():
     )
     
     # Process the stream
-    print("Receiving streamed response:")
+    print("Receiving streamed response:\\n")
     for chunk in completion:
         if chunk.choices[0].delta.content:
             print(chunk.choices[0].delta.content, end="")
-    print("\n")
+    print("\\n")
 
 def advanced_streaming_with_callback():
     """Advanced example showing custom stream handling"""
@@ -61,5 +61,5 @@ if __name__ == "__main__":
     print("Basic Streaming Example:")
     basic_streaming_example()
     
-    print("\nAdvanced Streaming Example:")
+    print("\\nAdvanced Streaming Example:")
     advanced_streaming_with_callback()

--- a/examples/o1/streaming_with_o1.py
+++ b/examples/o1/streaming_with_o1.py
@@ -1,0 +1,65 @@
+"""
+This example demonstrates how to use streaming with OpenAI's O1 API.
+It includes both basic and advanced streaming patterns.
+"""
+
+from openai import OpenAI
+import json
+
+def basic_streaming_example():
+    """Basic example of streaming with O1"""
+    client = OpenAI()
+    
+    # Create a streaming chat completion
+    completion = client.chat.completions.create(
+        model="o1-preview-2024-09-12",  # Use O1 preview model
+        messages=[
+            {"role": "user", "content": "Write a short story about a robot."}
+        ],
+        stream=True  # Enable streaming
+    )
+    
+    # Process the stream
+    print("Receiving streamed response:")
+    for chunk in completion:
+        if chunk.choices[0].delta.content:
+            print(chunk.choices[0].delta.content, end="")
+    print("\n")
+
+def advanced_streaming_with_callback():
+    """Advanced example showing custom stream handling"""
+    def process_stream(chunk):
+        """Custom stream processor"""
+        if chunk.choices[0].delta.content:
+            # Process the content (e.g., update UI, accumulate text)
+            return chunk.choices[0].delta.content
+        return ""
+    
+    client = OpenAI()
+    accumulated_text = ""
+    
+    # Create streaming completion with system message
+    completion = client.chat.completions.create(
+        model="o1-preview-2024-09-12",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Explain quantum computing briefly."}
+        ],
+        stream=True,
+        max_tokens=150
+    )
+    
+    # Process stream with callback
+    for chunk in completion:
+        text = process_stream(chunk)
+        accumulated_text += text
+        print(text, end="", flush=True)
+    
+    return accumulated_text
+
+if __name__ == "__main__":
+    print("Basic Streaming Example:")
+    basic_streaming_example()
+    
+    print("\nAdvanced Streaming Example:")
+    advanced_streaming_with_callback()


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1580](https://github.com/openai/openai-cookbook/pull/1580)
> **Original author:** @AllAboutAI-YT
> **Originally opened:** 2024-11-27

---

This PR adds examples for using streaming with the O1 API.

Changes:
- Added `examples/o1/streaming_with_o1.py` with basic and advanced streaming examples
- Demonstrates both simple streaming and custom stream handling
- Includes practical examples with the O1 preview model

The examples show:
1. Basic streaming setup with minimal configuration
2. Advanced streaming with custom callbacks and text accumulation
3. Best practices for stream handling

This helps developers understand how to effectively use streaming with the new O1 models.
