### PR TITLE
Network policy tip

### DIFF
--- a/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
@@ -287,6 +287,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Network policies can be applied at the account, security integration, and user level. The most specific network policy overrides the more general network policies. Depending on how these policies are applied, you may need to alter the policies for individual users in addition to the security integration. If you face this issue, you may encounter Snowflake's error code 390422."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### 2. Set up the Security Integration\n",
     "* Review the Snowflake OAuth Overview: [https://docs.snowflake.com/en/user-guide/oauth-snowflake-overview](https://docs.snowflake.com/en/user-guide/oauth-snowflake-overview)\n",
     "* Create new OAuth credentials through a [Security Integration](https://docs.snowflake.com/en/sql-reference/sql/create-security-integration-oauth-snowflake) - you will need a new one for each OAuth app/custom GPT since Snowflake Redirect URIs are 1-1 mapped to Security Integrations"


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1542](https://github.com/openai/openai-cookbook/pull/1542)
> **Original author:** @ray-openai
> **Originally opened:** 2024-10-31

---

## Summary

Applying security policies at the network integration level is not always enough. In some cases, policies must be updated at the user level as well. 

## Motivation

Addressing this issue will make adoption more self-serve and help customers in cases where the GPT's error messages are not highly specific and/or lack recommended action.
