### PR TITLE
Orchestrating_agents.ipynb word update "indate" to "indicate"

### DIFF
--- a/examples/Orchestrating_agents.ipynb
+++ b/examples/Orchestrating_agents.ipynb
@@ -596,7 +596,7 @@
     "\n",
     "Now that agent can express the _intent_ to make a handoff, we must make it actually happen. There's many ways to do this, but there's one particularly clean way.\n",
     "\n",
-    "For the agent functions we've defined so far, like `execute_refund` or `place_order` they return a string, which will be provided to the model. What if instead, we return an `Agent` object to indate which agent we want to transfer to? Like so:"
+    "For the agent functions we've defined so far, like `execute_refund` or `place_order` they return a string, which will be provided to the model. What if instead, we return an `Agent` object to indicate which agent we want to transfer to? Like so:"
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1541](https://github.com/openai/openai-cookbook/pull/1541)
> **Original author:** @thedayisntgray
> **Originally opened:** 2024-10-31

---

## Description
Fixed a typo in the documentation where "indate" was incorrectly used instead of "indicate". This change improves readability and maintains professional documentation standards.

## Summary
Fix typo: Change "indate" to "indicate" in the documentation.

## Motivation
This change corrects a spelling error to improve code documentation clarity and readability. Clear documentation helps reduce confusion for developers using the cookbook.

---
## For new content
Since this is a minor typo fix rather than new content, the new content checklist is not applicable. However, I have reviewed the change for:
- [x] Spelling and Grammar: Corrected the misspelling of "indicate"
- [x] Clarity: The fix improves document clarity
- [x] Correctness: The corrected spelling is accurate
