### PR TITLE
Ray/snowflake direct updates

### DIFF
--- a/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
@@ -266,12 +266,17 @@
     "  VALUE_LIST = ('23.102.140.112/28',\n",
     "                '13.66.11.96/28',\n",
     "                '104.210.133.240/28',\n",
+    "                '70.37.60.192/28',\n",
     "                '20.97.188.144/28',\n",
     "                '20.161.76.48/28',\n",
     "                '52.234.32.208/28',\n",
     "                '52.156.132.32/28',\n",
     "                '40.84.220.192/28',\n",
     "                '23.98.178.64/28',\n",
+    "                '51.8.155.32/28',\n",
+    "                '20.246.77.240/28',\n",
+    "                '172.178.141.0/28',\n",
+    "                '172.178.141.192/28',\n",
     "                '40.84.180.128/28');\n",
     "\n",
     "CREATE NETWORK POLICY chatgpt_network_policy\n",
@@ -304,8 +309,8 @@
     "  OAUTH_CLIENT_TYPE = 'CONFIDENTIAL'\n",
     "  OAUTH_REDIRECT_URI = 'https://oauth.pstmn.io/v1/callback' --- // this is a temporary value while testing your integration. You will replace this with the value your GPT provides\n",
     "  OAUTH_ISSUE_REFRESH_TOKENS = TRUE\n",
-    "  OAUTH_REFRESH_TOKEN_VALIDITY = 7776000;\n",
-    "  NETWORK_POLICY = chatgpt_network_policy --- // this line should only be included if you followed step 1 above"
+    "  OAUTH_REFRESH_TOKEN_VALIDITY = 7776000\n",
+    "  NETWORK_POLICY = chatgpt_network_policy; --- // this line should only be included if you followed step 1 above"
    ]
   },
   {
@@ -430,7 +435,7 @@
    },
    "outputs": [],
    "source": [
-    "ALTER SECURITY INTEGRATION CHATGPT_INTEGRATION_DEV SET OAUTH_REDIRECT_URI='https://chat.openai.com/aip/<callback_id>/oauth/callback';"
+    "ALTER SECURITY INTEGRATION CHATGPT_INTEGRATION SET OAUTH_REDIRECT_URI='https://chat.openai.com/aip/<callback_id>/oauth/callback';"
    ]
   },
   {

--- a/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
@@ -355,7 +355,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "* Retrieve your OAuth Client Secret"
+    "* Retrieve your OAuth Client Secret using SHOW_OAUTH_CLIENT_SECRETS"
    ]
   },
   {

--- a/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
@@ -400,7 +400,7 @@
     "| Client Secret   | OAUTH_CLIENT_SECRET from SHOW_OAUTH_CLIENT_SECRETS   |\n",
     "| Authorization URL   | OAUTH_AUTHORIZATION_ENDPOINT from DESCRIBE SECURITY INTEGRATION |\n",
     "| Token URL   | OAUTH_TOKEN_ENDPOINT from DESCRIBE SECURITY INTEGRATION   |\n",
-    "| Scope   | session:role:<your-role>*   |\n",
+    "| Scope   | session:role:your_role*   |\n",
     "| Token Exchange Method   | Default (POST Request)   |\n",
     "\n",
     "\n",

--- a/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
@@ -99,16 +99,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<details>\n",
-    "  <summary>Click to expand</summary>\n",
-    "  This is the content of the collapsible section. You can include any Markdown-formatted text, lists, or code here.\n",
-    "</details>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## ChatGPT Steps"
    ]
   },

--- a/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
@@ -99,6 +99,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<details>\n",
+    "  <summary>Click to expand</summary>\n",
+    "  This is the content of the collapsible section. You can include any Markdown-formatted text, lists, or code here.\n",
+    "</details>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## ChatGPT Steps"
    ]
   },

--- a/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
@@ -129,7 +129,7 @@
     "-- Assume warehouse = \"<insert your default warehouse here>\", database = \"<insert your default database here>\", unless the user provides different values \n",
     "2. Convert the user's question into a SQL statement that leverages the step above and run the `runQuery` operation on that SQL statement to confirm the query works. Add a limit of 100 rows\n",
     "3. Now remove the limit of 100 rows and return back the query for the user to see\n",
-    "4. Use the <your role> role when querying Snowflake\n",
+    "4. Use the <your_role> role when querying Snowflake\n",
     "5. Run each step in sequence. Explain what you are doing in a few sentences, run the action, and then explain what you learned. This will help the user understand the reason behind your workflow. \n",
     "\n",
     "**Additional Notes**: If the user says \"Let's get started\", explain that the user can provide a project or dataset, along with a question they want answered. If the user has no ideas, suggest that we have a sample flights dataset they can query - ask if they want you to query that"
@@ -404,7 +404,7 @@
     "| Token Exchange Method   | Default (POST Request)   |\n",
     "\n",
     "\n",
-    "*Snowflake scopes pass the role in the format `session:role:<your-role>` for example `session:role:CHATGPT_INTEGRATION_ROLE`. It's possible to leave this empty and specify the role in the instructions, but by adding it here it becomes included in OAuth Consent Request which can sometimes be more reliable. "
+    "*Snowflake scopes pass the role in the format `session:role:<your_role>` for example `session:role:CHATGPT_INTEGRATION_ROLE`. It's possible to leave this empty and specify the role in the instructions, but by adding it here it becomes included in OAuth Consent Request which can sometimes be more reliable. "
    ]
   },
   {

--- a/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
@@ -368,7 +368,7 @@
    },
    "outputs": [],
    "source": [
-    "select SYSTEM$SHOW_OAUTH_CLIENT_SECRETS('CHATGPT_INTEGRATION');"
+    "SELECT trim(parse_json(SYSTEM$SHOW_OAUTH_CLIENT_SECRETS('CHATGPT_INTEGRATION')):OAUTH_CLIENT_ID) AS OAUTH_CLIENT_ID, trim(parse_json(SYSTEM$SHOW_OAUTH_CLIENT_SECRETS('CHATGPT_INTEGRATION')):OAUTH_CLIENT_SECRET) AS OAUTH_CLIENT_SECRET;"
    ]
   },
   {
@@ -398,6 +398,7 @@
     "| -------- | -------- |\n",
     "| Authentication Type   | OAuth   |\n",
     "| Client ID   | OAUTH_CLIENT_ID from SHOW_OAUTH_CLIENT_SECRETS   |\n",
+    "| Client Secret   | OAUTH_CLIENT_SECRET from SHOW_OAUTH_CLIENT_SECRETS   |\n",
     "| Authorization URL   | OAUTH_AUTHORIZATION_ENDPOINT from DESCRIBE SECURITY INTEGRATION |\n",
     "| Token URL   | OAUTH_TOKEN_ENDPOINT from DESCRIBE SECURITY INTEGRATION   |\n",
     "| Scope   | &lt;empty>*   |\n",

--- a/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
@@ -258,7 +258,7 @@
    },
    "outputs": [],
    "source": [
-    "## Example with ChatGPT IPs as of September 19, 2024\n",
+    "## Example with ChatGPT IPs as of October 23, 2024\n",
     "## Make sure to get the current IP ranges from https://platform.openai.com/docs/actions/production\n",
     "CREATE NETWORK RULE chatgpt_network_rule\n",
     "  MODE = INGRESS\n",

--- a/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
@@ -125,7 +125,7 @@
     "**Context**: You are an expert at writing Snowflake SQL queries. A user is going to ask you a question. \n",
     "\n",
     "**Instructions**:\n",
-    "1. No matter the user's question, start by running `runQuery` operation using this query: \"SELECT column_name, table_name, data_type, comment FROM `{database}.INFORMATION_SCHEMA.COLUMNS`\" \n",
+    "1. No matter the user's question, start by running `runQuery` operation using this query: \"SELECT column_name, table_name, data_type, comment FROM {database}.INFORMATION_SCHEMA.COLUMNS\" \n",
     "-- Assume warehouse = \"<insert your default warehouse here>\", database = \"<insert your default database here>\", unless the user provides different values \n",
     "2. Convert the user's question into a SQL statement that leverages the step above and run the `runQuery` operation on that SQL statement to confirm the query works. Add a limit of 100 rows\n",
     "3. Now remove the limit of 100 rows and return back the query for the user to see\n",

--- a/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
@@ -368,16 +368,15 @@
    },
    "outputs": [],
    "source": [
-    "SELECT trim(parse_json(SYSTEM$SHOW_OAUTH_CLIENT_SECRETS('CHATGPT_INTEGRATION')):OAUTH_CLIENT_ID) AS OAUTH_CLIENT_ID, trim(parse_json(SYSTEM$SHOW_OAUTH_CLIENT_SECRETS('CHATGPT_INTEGRATION')):OAUTH_CLIENT_SECRET) AS OAUTH_CLIENT_SECRET;"
+    "SELECT \n",
+    "trim(parse_json(SYSTEM$SHOW_OAUTH_CLIENT_SECRETS('CHATGPT_INTEGRATION')):OAUTH_CLIENT_ID) AS OAUTH_CLIENT_ID\n",
+    ", trim(parse_json(SYSTEM$SHOW_OAUTH_CLIENT_SECRETS('CHATGPT_INTEGRATION')):OAUTH_CLIENT_SECRET) AS OAUTH_CLIENT_SECRET;"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
-    "You’ll find the Client Secret in OAUTH_CLIENT_SECRET. Do not include the double quotes when copying the value.\n",
-    "\n",
     "Now is a good time to [test your Snowflake integration in Postman](https://community.snowflake.com/s/article/How-to-configure-postman-for-testing-SQL-API-with-OAuth). If you configured a network policy for your security integration, ensure that it includes the IP of the machine you're using to test."
    ]
   },

--- a/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
@@ -400,11 +400,11 @@
     "| Client Secret   | OAUTH_CLIENT_SECRET from SHOW_OAUTH_CLIENT_SECRETS   |\n",
     "| Authorization URL   | OAUTH_AUTHORIZATION_ENDPOINT from DESCRIBE SECURITY INTEGRATION |\n",
     "| Token URL   | OAUTH_TOKEN_ENDPOINT from DESCRIBE SECURITY INTEGRATION   |\n",
-    "| Scope   | &lt;empty>*   |\n",
+    "| Scope   | session:role:<your-role>*   |\n",
     "| Token Exchange Method   | Default (POST Request)   |\n",
     "\n",
     "\n",
-    "*Snowflake scopes pass the role, but you’ll notice the action itself also specifies the role as a parameter in runQuery, so the Scope is unnecessary. You may elect to pass roles in the scope instead of the action parameters if it makes more sense for your GPT."
+    "*Snowflake scopes pass the role in the format `session:role:<your-role>` for example `session:role:CHATGPT_INTEGRATION_ROLE`. It's possible to leave this empty and specify the role in the instructions, but by adding it here it becomes included in OAuth Consent Request which can sometimes be more reliable. "
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1514](https://github.com/openai/openai-cookbook/pull/1514)
> **Original author:** @ray-openai
> **Originally opened:** 2024-10-23

---

## Summary

Various updates to the chatgpt gpt action snowflake direct cookbook

## Motivation

Running through the instructions again led to a few points of friction. This PR addresses each of those:

- remove semicolon from create integration rule
- rename chatgpt_integration_dev to chatgpt_integration in alter statement at the end
- update the IP addresses
- add client secret to table of oauth inputs
- remove backticks from information_schema.columns in instructions
- set scope explicitly in oauth instead of leaving blank
