### PR TITLE
#1472 Fixed "Conretely" typo in Orchestrating_agents.ipynb

### DIFF
--- a/examples/Orchestrating_agents.ipynb
+++ b/examples/Orchestrating_agents.ipynb
@@ -46,7 +46,7 @@
    "source": [
     "# Routines\n",
     "\n",
-    "The notion of a \"routine\" is not strictly defined, and instead meant to capture the idea of a set of steps. Conretely, let's define a routine to be a list of instructions in natural langauge (which we'll represent with a system prompt), along with the tools necessary to complete them.\n",
+    "The notion of a \"routine\" is not strictly defined, and instead meant to capture the idea of a set of steps. Concretely, let's define a routine to be a list of instructions in natural langauge (which we'll represent with a system prompt), along with the tools necessary to complete them.\n",
     "\n",
     "\n",
     "\n",


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1476](https://github.com/openai/openai-cookbook/pull/1476)
> **Original author:** @nickjfrench
> **Originally opened:** 2024-10-15

---

## Summary

Replaced "Conretely" with "Concretely" in the first paragraph under Routines.

## Motivation

Improve user readability.

---

## For new content

N/A
