### PR TITLE
Update Orchestrating_agents.ipynb

### DIFF
--- a/examples/Orchestrating_agents.ipynb
+++ b/examples/Orchestrating_agents.ipynb
@@ -460,7 +460,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now to make our code support it, we can change `run_full_turn` take an `Agent` instead of separate `system_message` and `tools`:"
+    "Now to make our code support it, we can change `run_full_turn` to take an `Agent` instead of separate `system_message` and `tools`:"
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1470](https://github.com/openai/openai-cookbook/pull/1470)
> **Original author:** @dazzaji
> **Originally opened:** 2024-10-13

---

fixed the sentence

## Summary

The sentence is missing a preposition before "take an Agent." It should be "change run_full_turn to take an Agent."

## Motivation

Correct this sentence in the documentation to it's more readable and easier to understand the meaning.
