### PR TITLE
add tiktoken_ruby as a tokenizer lib in Ruby

### DIFF
--- a/examples/How_to_count_tokens_with_tiktoken.ipynb
+++ b/examples/How_to_count_tokens_with_tiktoken.ipynb
@@ -51,6 +51,7 @@
     "- PHP: [GPT-3-Encoder-PHP](https://github.com/CodeRevolutionPlugins/GPT-3-Encoder-PHP)\n",
     "- Golang: [tiktoken-go](https://github.com/pkoukk/tiktoken-go)\n",
     "- Rust: [tiktoken-rs](https://github.com/zurawiki/tiktoken-rs)\n",
+    "- Ruby: [tiktoken_ruby](https://github.com/IAPark/tiktoken_ruby)\n",
     "\n",
     "(OpenAI makes no endorsements or guarantees of third-party libraries.)\n",
     "\n",


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1468](https://github.com/openai/openai-cookbook/pull/1468)
> **Original author:** @qoosuperman
> **Originally opened:** 2024-10-13

---

## Summary

add tiktoken_ruby as a tokenizer library in Ruby

## Motivation

See summary

