### PR TITLE
Fix Typo Conretely > Concretely

### DIFF
--- a/examples/Orchestrating_agents.ipynb
+++ b/examples/Orchestrating_agents.ipynb
@@ -46,7 +46,7 @@
    "source": [
     "# Routines\n",
     "\n",
-    "The notion of a \"routine\" is not strictly defined, and instead meant to capture the idea of a set of steps. Conretely, let's define a routine to be a list of instructions in natural langauge (which we'll repreesnt with a system prompt), along with the tools necessary to complete them.\n",
+    "The notion of a \"routine\" is not strictly defined, and instead meant to capture the idea of a set of steps. Concretely, let's define a routine to be a list of instructions in natural langauge (which we'll repreesnt with a system prompt), along with the tools necessary to complete them.\n",
     "\n",
     "\n",
     "\n",


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1466](https://github.com/openai/openai-cookbook/pull/1466)
> **Original author:** @joelklabo
> **Originally opened:** 2024-10-12

---

## Summary

Fix typo in Orchestrating Agents section
