### PR TITLE
Fix registry tags

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -1605,7 +1605,7 @@
   authors:
     - msingh-openai
   tags:
-    - web-browsing
+    - completions
 
 - title: Prompt Caching 101 
   path: examples/Prompt_Caching101.ipynb
@@ -1613,7 +1613,4 @@
   authors:
     - charuj
   tags:
-    - latency
-    - cost
-    - prompt caching
     - completions


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1452](https://github.com/openai/openai-cookbook/pull/1452)
> **Original author:** @ericning-o
> **Originally opened:** 2024-10-07

---

## Summary

Some tags aren't supported, so let's remove them
