### PR TITLE
Cleanup unused guides and typo

### DIFF
--- a/examples/o1/Using_chained_calls_for_o1_structured_outputs.ipynb
+++ b/examples/o1/Using_chained_calls_for_o1_structured_outputs.ipynb
@@ -129,7 +129,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's now do this with [structured outputs.](https://platform.openai.com/docs/guides/structured-outputs). To enable this functionality, we’ll link the `o1-preview` response with a follow-up request to `gpt-4o-mini`, which can effectively process the data returned from the initial o1-preview response."
+    "Let's now do this with [structured outputs](https://platform.openai.com/docs/guides/structured-outputs). To enable this functionality, we’ll link the `o1-preview` response with a follow-up request to `gpt-4o-mini`, which can effectively process the data returned from the initial o1-preview response."
    ]
   },
   {

--- a/registry.yaml
+++ b/registry.yaml
@@ -384,14 +384,6 @@
   tags:
     - embeddings
 
-- title: Azure DALL·E image generation example
-  path: examples/azure/DALL-E.ipynb
-  date: 2023-06-12
-  authors:
-    - glecaros
-  tags:
-    - dall-e
-
 - title: Azure Chat Completions example (preview)
   path: examples/azure/chat.ipynb
   date: 2023-03-28
@@ -408,17 +400,6 @@
   authors:
     - kristapratico
   tags:
-    - completions
-
-- title: Azure completions example
-  path: examples/azure/completions.ipynb
-  date: 2022-12-16
-  authors:
-    - cmurtz-msft
-    - glecaros
-    - kristapratico
-  tags:
-    - embeddings
     - completions
 
 - title: Azure embeddings example


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1429](https://github.com/openai/openai-cookbook/pull/1429)
> **Original author:** @ericning-o
> **Originally opened:** 2024-09-26

---

## Summary

Fixing a typo and also removing guides that aren't actually referenced.

## Motivation

See summary

