### PR TITLE
fix typo in python code example

### DIFF
--- a/examples/Chat_finetuning_data_prep.ipynb
+++ b/examples/Chat_finetuning_data_prep.ipynb
@@ -267,7 +267,7 @@
     "print_distribution(n_messages, \"num_messages_per_example\")\n",
     "print_distribution(convo_lens, \"num_total_tokens_per_example\")\n",
     "print_distribution(assistant_message_lens, \"num_assistant_tokens_per_example\")\n",
-    "n_too_long = sum(l > 16,385 for l in convo_lens)\n",
+    "n_too_long = sum(l > 16385 for l in convo_lens)\n",
     "print(f\"\\n{n_too_long} examples may be over the 16,385 token limit, they will be truncated during fine-tuning\")"
    ]
   },


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1413](https://github.com/openai/openai-cookbook/pull/1413)
> **Original author:** @kwhinnery-openai
> **Originally opened:** 2024-09-19

---

On the tin :)
