### PR TITLE
[typo] Replace 'mostly likely' with 'most likely'

### DIFF
--- a/articles/how_to_work_with_large_language_models.md
+++ b/articles/how_to_work_with_large_language_models.md
@@ -55,7 +55,7 @@ Ted Chiang
 
 ### Completion prompt example
 
-Completion-style prompts take advantage of how large language models try to write text they think is mostly likely to come next. To steer the model, try beginning a pattern or sentence that will be completed by the output you want to see. Relative to direct instructions, this mode of steering large language models can take more care and experimentation. In addition, the models won't necessarily know where to stop, so you will often need stop sequences or post-processing to cut off text generated beyond the desired output.
+Completion-style prompts take advantage of how large language models try to write text they think is most likely to come next. To steer the model, try beginning a pattern or sentence that will be completed by the output you want to see. Relative to direct instructions, this mode of steering large language models can take more care and experimentation. In addition, the models won't necessarily know where to stop, so you will often need stop sequences or post-processing to cut off text generated beyond the desired output.
 
 Example completion prompt:
 


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1395](https://github.com/openai/openai-cookbook/pull/1395)
> **Original author:** @AntonioClarke
> **Originally opened:** 2024-08-28

---

## Summary

I believe this is a typo, and that this text should say "most likely", as in LLMs try to write text that has the highest probability of coming next, as opposed to "mostly likely". 

The only reference I can find to the difference between the two terms is [here](https://english.stackexchange.com/questions/412416/most-likely-or-mostly-likely#:~:text=There's%20also%20one%20more%20important,mostly%20likely%20red%22%20is%20not.), that said, it appears to be more of a theoretical consideration, and a brief skim of the internet returns very few results for "mostly likely". It's unclear what it would mean in this context for the generated text to be "mostly likely" - if it did in fact mean "mostly likely" rather than "most likely", there are likely clearer ways of articulating that given the rarity of this phrase.

I did not list myself as an author in `registry.yaml` as updating a typo should likely not count as authorship. Please let me know if this should be changed.

## Motivation

Not having typos is always better than having typos. This is obviously a marginal improvement, but given that the README for this repo explicitly said:

> Whether you're submitting an idea, fixing a typo, adding a new guide, or improving an existing one, your contributions are greatly appreciated!

I assumed that this change would be worth putting up, and meets the "Relevance" bar

---

## For new content

When contributing new content, read through our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md), and mark the following action items as completed:

- [ x] I have added a new entry in [registry.yaml](https://github.com/openai/openai-cookbook/blob/main/registry.yaml) (and, optionally, in [authors.yaml](https://github.com/openai/openai-cookbook/blob/main/authors.yaml)) so that my content renders on the cookbook website.
- [x] I have conducted a self-review of my content based on the [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md#rubric):
  - [ x] Relevance: This content is related to building with OpenAI technologies and is useful to others.
  - [ x] Uniqueness: I have searched for related examples in the OpenAI Cookbook, and verified that my content offers new insights or unique information compared to existing documentation.
  - [x ] Spelling and Grammar: I have checked for spelling or grammatical mistakes.
  - [x ] Clarity: I have done a final read-through and verified that my submission is well-organized and easy to understand.
  - [x ] Correctness: The information I include is correct and all of my code executes successfully.
  - [x ] Completeness: I have explained everything fully, including all necessary references and citations.

We will rate each of these areas on a scale from 1 to 4, and will only accept contributions that score 3 or higher on all areas. Refer to our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md) for more details.
