### PR TITLE
Fix typo

### DIFF
--- a/examples/chatgpt/gpt_actions_library/gpt_action_zapier.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_zapier.ipynb
@@ -21,7 +21,7 @@
     "This page provides an instruction & guide for developers building a GPT Action for a specific application. Before you proceed, make sure to first familiarize yourself with the following information: \n",
     "- [Introduction to GPT Actions](https://platform.openai.com/docs/actions)\n",
     "- [Introduction to GPT Actions Library](https://platform.openai.com/docs/actions/actions-library)\n",
-    "- [Example of Buliding a GPT Action from Scratch](https://platform.openai.com/docs/actions/getting-started)"
+    "- [Example of Building a GPT Action from Scratch](https://platform.openai.com/docs/actions/getting-started)"
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1369](https://github.com/openai/openai-cookbook/pull/1369)
> **Original author:** @cantaspinar
> **Originally opened:** 2024-08-10

---

## Summary

Fixes the typo in gpt_action_zapier.ipynb file.
