### PR TITLE
fix tags

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -1453,6 +1453,9 @@
   date: 2024-07-31
   authors:
     - evanweiss-openai
+  tags:
+    - chatgpt
+    - gpt-actions-library
 
 - title: GPT Actions library - Box
   path: examples/chatgpt/gpt_actions_library/gpt_action_box.ipynb


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1361](https://github.com/openai/openai-cookbook/pull/1361)
> **Original author:** @pap-openai
> **Originally opened:** 2024-08-07

---

## Summary

Fix registry.yml tags

## Motivation

Cookbook can't be deployed as of now and requires tags for each entry
