### PR TITLE
Remove Guardrails.ai from related_resources.md because it returns 404

### DIFF
--- a/articles/related_resources.md
+++ b/articles/related_resources.md
@@ -9,7 +9,6 @@ People are writing great tools and papers for improving outputs from GPT. Here a
 - [Chainlit](https://docs.chainlit.io/overview): A Python library for making chatbot interfaces.
 - [Embedchain](https://github.com/embedchain/embedchain): A Python library for managing and syncing unstructured data with LLMs.
 - [FLAML (A Fast Library for Automated Machine Learning & Tuning)](https://microsoft.github.io/FLAML/docs/Getting-Started/): A Python library for automating selection of models, hyperparameters, and other tunable choices.
-- [Guardrails.ai](https://shreyar.github.io/guardrails/): A Python library for validating outputs and retrying failures. Still in alpha, so expect sharp edges and bugs.
 - [Guidance](https://github.com/microsoft/guidance): A handy looking Python library from Microsoft that uses Handlebars templating to interleave generation, prompting, and logical control.
 - [Haystack](https://github.com/deepset-ai/haystack): Open-source LLM orchestration framework to build customizable, production-ready LLM applications in Python.
 - [HoneyHive](https://honeyhive.ai): An enterprise platform to evaluate, debug, and monitor LLM apps.


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1256](https://github.com/openai/openai-cookbook/pull/1256)
> **Original author:** @SemperDisco
> **Originally opened:** 2024-06-25

---

## Summary

Remove Guardrails.ai from related_resources.md because it returns 404.

## Motivation

Keep the related resources up-to-date.
