### PR TITLE
Correct grammatical errors in Markdown cells

### DIFF
--- a/examples/fine-tuned_qa/olympics-1-collect-data.ipynb
+++ b/examples/fine-tuned_qa/olympics-1-collect-data.ipynb
@@ -407,7 +407,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There appear to be winter and summer Olympics 2020. We chose to leave a little ambiguity and noise in the dataset, even though we were interested in only Summer Olympics 2020."
+    "There appear to be winter and summer Olympics 2020. We chose to leave a little ambiguity and noise in the dataset, even though we were interested only in the Summer Olympics 2020."
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1235](https://github.com/openai/openai-cookbook/pull/1235)
> **Original author:** @CharlesCNorton
> **Originally opened:** 2024-06-01

---

This PR corrects the placement of "only" and adds "the" in a Markdown cell.

These changes are necessary to adhere to proper grammatical rules, ensuring clarity and readability in the documentation. Proper grammar and clarity are essential for maintaining the quality and professionalism of the OpenAI Cookbook.

---

- [ ] I have added a new entry in [registry.yaml](https://github.com/openai/openai-cookbook/blob/main/registry.yaml) (and, optionally, in [authors.yaml](https://github.com/openai/openai-cookbook/blob/main/authors.yaml)) so that my content renders on the cookbook website. (Not applicable)
- [x] I have conducted a self-review of my content based on the [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md#rubric):
  - [x] Relevance: This content is related to building with OpenAI technologies and is useful to others.
  - [x] Uniqueness: I have searched for related examples in the OpenAI Cookbook and verified that my content offers new insights or unique information compared to existing documentation. (Not applicable)
  - [x] Spelling and Grammar: I have checked for spelling or grammatical mistakes.
  - [x] Clarity: I have done a final read-through and verified that my submission is well-organized and easy to understand.
  - [x] Correctness: The information I include is correct and all of my code executes successfully.
  - [x] Completeness: I have explained everything fully, including all necessary references and citations.

Rephrase for clarity by moving "only" to its proper position and adding "the". The revised sentence reads: "We chose to leave a little ambiguity and noise in the dataset, even though we were interested only in the Summer Olympics 2020." According to the rule of correct placement for limiting modifiers, "only" should be placed immediately before the word or phrase it modifies to avoid ambiguity. Adding "the" ensures proper article usage.

- The changes ensure that the documentation adheres to standard grammatical rules, enhancing readability and professionalism.
- These improvements contribute to the overall quality of the OpenAI Cookbook, making it easier for users to understand and follow the examples.
