### PR TITLE
fix date for GPT-4o page

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -1111,7 +1111,7 @@
 
 - title: Processing and narrating a video with GPT's visual capabilities and the TTS API
   path: examples/GPT_with_vision_for_video_understanding.ipynb
-  date: 2023-11-06
+  date: 2024-05-13
   authors:
     - cathykc
   tags:


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1215](https://github.com/openai/openai-cookbook/pull/1215)
> **Original author:** @nch0w
> **Originally opened:** 2024-05-16

---

## Summary

Minor fix of the date on this page (updated so it matches GPT-4o release date).
