### PR TITLE
Bump stale action to latest version

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v9
         with:
           stale-issue-message: "This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 10 days."
           stale-pr-message: "This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 10 days."


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1142](https://github.com/openai/openai-cookbook/pull/1142)
> **Original author:** @deining
> **Originally opened:** 2024-04-11

---

This PR bumps GitHub stale workflow action to its latest version, thus avoiding deprecation warning as seen e.g. [here](https://github.com/openai/openai-cookbook/actions/runs/8640318310).
