### PR TITLE
Updated Weaviate Docker image url (auto PR by bot)

### DIFF
--- a/examples/vector_databases/weaviate/docker-compose.yml
+++ b/examples/vector_databases/weaviate/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     - '8080'
     - --scheme
     - http
-    image: semitechnologies/weaviate:1.17.2
+    image: cr.weaviate.io/semitechnologies/weaviate:1.17.2
     ports:
     - 8080:8080
     restart: on-failure:0


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1104](https://github.com/openai/openai-cookbook/pull/1104)
> **Original author:** @weaviate-git-bot
> **Originally opened:** 2024-03-17

---

This minor change updates the URL of the [Weaviate Docker image](https://weaviate.io/developers/weaviate/installation/docker-compose).

​Instead of the standard Docker registry, Weaviate now makes use of a custom registry running at `cr.weaviate.io`.

Thanks in advance for ​merging.

🤖 beep boop, the Weaviate bot

PS:
Please note that the Weaviate Bot automates this PR; apologies if PR formatting is missing. If you have questions, feel free to reach out via our [forum](https://forum.weaviate.io) or [Slack](https://weaviate.io/slack).
