### PR TITLE
fix spelling

### DIFF
--- a/examples/Assistants_API_overview_python.ipynb
+++ b/examples/Assistants_API_overview_python.ipynb
@@ -1156,7 +1156,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once again, let's update out Assistant either through the Dashboard or the API.\n"
+    "Once again, let's update our Assistant either through the Dashboard or the API.\n"
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1081](https://github.com/openai/openai-cookbook/pull/1081)
> **Original author:** @MorganMarshall
> **Originally opened:** 2024-03-01

---

## Summary
Basic spelling update fixing typo "out" to "our":
From: Once again, let's update out Assistant either through the Dashboard or the API
To: Once again, let's update our Assistant either through the Dashboard or the API
