### PR TITLE
Update registry.yaml

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -1195,7 +1195,7 @@
   tags:
     - guardrails
 
-- title: How to combine GPTV with RAG Create a Clothing Matchmaker App
+- title: How to combine GPT-V with RAG to create a clothing matchmaker app
   path: examples/How_to_Combine_GPTv_with_RAG_Outfit_Assistant.ipynb
   date: 2024-02-16
   authors:

--- a/registry.yaml
+++ b/registry.yaml
@@ -164,15 +164,6 @@
     - completions
     - functions
 
-- title: How to combine GPTV with RAG Create a Clothing Matchmaker App
-  path: examples/How_to_Combine_GPTv_with_RAG_Outfit_Assistant.ipynb
-  date: 2024-02-16
-  authors:
-    - teomusatoiu
-  tags:
-    - vision
-    - embeddings
-
 - title: How to count tokens with tiktoken
   path: examples/How_to_count_tokens_with_tiktoken.ipynb
   date: 2022-12-16
@@ -1203,3 +1194,12 @@
     - colin-jarvis
   tags:
     - guardrails
+
+- title: How to combine GPTV with RAG Create a Clothing Matchmaker App
+  path: examples/How_to_Combine_GPTv_with_RAG_Outfit_Assistant.ipynb
+  date: 2024-02-16
+  authors:
+    - teomusatoiu
+  tags:
+    - vision
+    - embeddings


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1076](https://github.com/openai/openai-cookbook/pull/1076)
> **Original author:** @teomusatoiu
> **Originally opened:** 2024-02-27

---

## Summary
Change registry.yaml to show the GPTv+RAG cookbook

## Motivation
The cookbook is currently not showing up on the website. 
