### PR TITLE
Fix syntax error in DALL-E notebook

### DIFF
--- a/examples/dalle/Image_generations_edits_and_variations_with_DALL-E.ipynb
+++ b/examples/dalle/Image_generations_edits_and_variations_with_DALL-E.ipynb
@@ -110,7 +110,7 @@
     "\n",
     "# call the OpenAI API\n",
     "generation_response = client.images.generate(\n",
-    "    model = \"dall-e-3\"\n",
+    "    model = \"dall-e-3\",\n",
     "    prompt=prompt,\n",
     "    n=1,\n",
     "    size=\"1024x1024\",\n",


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1036](https://github.com/openai/openai-cookbook/pull/1036)
> **Original author:** @zanieb
> **Originally opened:** 2024-02-02

---

Similar to https://github.com/openai/openai-cookbook/pull/964, this notebook is failing our ecosystem checks over in Ruff due to a syntax error which is resolved by adding the missing `,`.
