### PR TITLE
Add functionality to store results in same order as request file.

### DIFF
--- a/examples/api_request_parallel_processor.py
+++ b/examples/api_request_parallel_processor.py
@@ -263,9 +263,15 @@ async def process_api_requests_from_file(
             sort_newly_appended_rows_by_taskid(save_filepath, status_tracker.num_tasks_started)
         remove_task_ids(save_filepath) # removes task ids from lines
 
-        logging.info(
-            f"""Parallel processing complete. Results saved to {save_filepath}"""
-        )
+        if not sort_results:
+            logging.info(
+                f"Parallel processing complete. Results saved to {save_filepath}. Note that the order may differ from input, use --sort_results flag to sort."
+            )
+        else:
+            logging.info(
+                f"Parallel processing complete. Results sorted and saved to {save_filepath}."
+            )
+        
         if status_tracker.num_tasks_failed > 0:
             logging.warning(
                 f"{status_tracker.num_tasks_failed} / {status_tracker.num_tasks_started} requests failed. Errors logged to {save_filepath}."


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#1005](https://github.com/openai/openai-cookbook/pull/1005)
> **Original author:** @tomdries
> **Originally opened:** 2024-01-12

---

## Summary

The flag --sort_results was added to sort the final results in the same order as the input file.

## Motivation

I use this script for large, monotonic batch jobs and I made some mistakes earlier, because I assumed the results would appear in the same order as the input file. However, due to the asynchronous nature, this is not the case. I implemented the functionality as an extra option so the script functions the same as before if no flag is given, but I imagine future versions may do the sorting by default, to avoid confusion.

---

## For new content

When contributing new content, read through our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md), and mark the following action items as completed:

- [x] I have added a new entry in [registry.yaml](https://github.com/openai/openai-cookbook/blob/main/registry.yaml) (and, optionally, in [authors.yaml](https://github.com/openai/openai-cookbook/blob/main/authors.yaml)) so that my content renders on the cookbook website.
- [x] I have conducted a self-review of my content based on the [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md#rubric):
  - [x] Relevance: This content is related to building with OpenAI technologies and is useful to others.
  - [x] Uniqueness: I have searched for related examples in the OpenAI Cookbook, and verified that my content offers new insights or unique information compared to existing documentation.
  - [x] Spelling and Grammar: I have checked for spelling or grammatical mistakes.
  - [x] Clarity: I have done a final read-through and verified that my submission is well-organized and easy to understand.
  - [x] Correctness: The information I include is correct and all of my code executes successfully.
  - [x] Completeness: I have explained everything fully, including all necessary references and citations.

We will rate each of these areas on a scale from 1 to 4, and will only accept contributions that score 3 or higher on all areas. Refer to our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md) for more details.
