### PR TITLE
docs: fix typo in olympics-3-train-qa.ipynb

### DIFF
--- a/examples/fine-tuned_qa/olympics-3-train-qa.ipynb
+++ b/examples/fine-tuned_qa/olympics-3-train-qa.ipynb
@@ -226,7 +226,7 @@
     "    - one originating from the same wikipedia article\n",
     "    - another, which is most similar to the correct context\n",
     "\n",
-    "This process is noisy, as sometimes the question might be answerable given a different context, but on average we hope this won't affect the peformance too much.\n",
+    "This process is noisy, as sometimes the question might be answerable given a different context, but on average we hope this won't affect the performance too much.\n",
     "\n",
     "We apply the same process of dataset creation for both the discriminator, and the Q&A answering model. We apply the process separately for the training and testing set, to ensure that the examples from the training set don't feature within the test set."
    ]


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#882](https://github.com/openai/openai-cookbook/pull/882)
> **Original author:** @eltociear
> **Originally opened:** 2023-11-27

---


## Summary

peformance -> performance
