### PR TITLE
Fix URLs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,10 +10,10 @@ Why are these changes necessary? How do they improve the cookbook?
 
 ## For new content
 
-When contributing new content, read through our [contribution guidelines](https://github.com/openai/openai-cookbook/CONTRIBUTING), and mark the following action items as completed:
+When contributing new content, read through our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md), and mark the following action items as completed:
 
 - [ ] I have added a new entry in [registry.yaml](/registry.yaml) so that my content renders on the cookbook website.
-- [ ] I have conducted a self-review of my content based on the [contribution guidelines](https://github.com/openai/openai-cookbook/CONTRIBUTING#rubric):
+- [ ] I have conducted a self-review of my content based on the [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md#rubric):
   - [ ] Relevance: This content is related to building with OpenAI technlogies and is useful to others.
   - [ ] Uniqueness: I have searched for related examples in the OpenAI Cookbook, and verified that my content offers new insights or unique information compared to existing documentation.
   - [ ] Spelling and Grammar: I have checked for spelling or grammatical mistakes.
@@ -21,4 +21,4 @@ When contributing new content, read through our [contribution guidelines](https:
   - [ ] Correctness: The information I include is correct and all of my code executes successfully.
   - [ ] Completeness: I have explained everything fully, including all necessary references and citations.
 
-We will rate each of these areas on a scale from 1 to 4, and will only accept contributions that score 3 or higher on all areas. Refer to our [contribution guidelines](https://github.com/openai/openai-cookbook/CONTRIBUTING) for more details.
+We will rate each of these areas on a scale from 1 to 4, and will only accept contributions that score 3 or higher on all areas. Refer to our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md) for more details.


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#815](https://github.com/openai/openai-cookbook/pull/815)
> **Original author:** @simonpfish
> **Originally opened:** 2023-10-31

---

## Summary

URLs were missing the `blob` 
