### PR TITLE
Add api_request_parallel_processor.py to registry for cookbook website, update link

### DIFF
--- a/examples/How_to_handle_rate_limits.ipynb
+++ b/examples/How_to_handle_rate_limits.ipynb
@@ -586,7 +586,7 @@
    "source": [
     "## Example parallel processing script\n",
     "\n",
-    "We've written an example script for parallel processing large quantities of API requests: [api_request_parallel_processor.py](https://github.com/openai/openai-cookbook/blob/main/examples/api_request_parallel_processor.py).\n",
+    "We've written an example script for parallel processing large quantities of API requests: [api_request_parallel_processor.py](api_request_parallel_processor.py).\n",
     "\n",
     "The script combines some handy features:\n",
     "- Streams requests from file, to avoid running out of memory for giant jobs\n",

--- a/registry.yaml
+++ b/registry.yaml
@@ -177,6 +177,15 @@
     - completions
     - embeddings
 
+- title: "API Request Parallel Processor"
+  path: "examples/api_request_parallel_processor.py"
+  date: 2023-01-20
+  authors: 
+    - "ted-at-openai"
+  tags:
+    - "completions"
+    - "embeddings"
+
 - title: How to stream completions
   path: examples/How_to_stream_completions.ipynb
   date: 2022-09-02


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#781](https://github.com/openai/openai-cookbook/pull/781)
> **Original author:** @cathykc
> **Originally opened:** 2023-10-12

---

Cookbook website now supports Python files. Adding `examples/api_request_parallel_processor.py` as an entry in the registry.

Should probably be merged after the website gets redeployed? https://github.com/openai/cookbook-website/pull/9
