### PR TITLE
add notebook for Named Entity Recognition (NER)

### DIFF
--- a/examples/Named_Entity_Recognition.ipynb
+++ b/examples/Named_Entity_Recognition.ipynb
@@ -1,0 +1,438 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Named Entity Recognition (NER)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Named Entity Recognition (NER) is a Natural Language Processing (NLP) task that identifies and classifies Named Entities (NE) into predefined semantic categories such as persons, organizations, locations, events, time expressions and quantities. It serves as the foundation for many NLP such as semantic annotation, question answering, text summarization, and machine translation.\n",
+    "\n",
+    "This notebook performs NER with [OpenAI ChatCompletion](https://platform.openai.com/docs/api-reference/chat)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 1.1 Upgrade to the latest OpenAI python package "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install --upgrade openai --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 1.2 Load packages and OPENAI_API_KEY"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can generate an API key in the OpenAI web interface. See https://platform.openai.com/account/api-keys for details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "import openai\n",
+    "\n",
+    "OPENAI_MODEL = 'gpt-3.5-turbo'\n",
+    "\n",
+    "openai.api_key = os.getenv(\"OPENAI_API_KEY\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Define the NER Categories to be Recognized"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ner_labels = [\n",
+    "    \"PERSON\",      # People, including fictional characters\n",
+    "    \"NORP\",        # Nationalities or religious or political groups\n",
+    "    \"FAC\",         # Buildings, airports, highways, bridges\n",
+    "    \"ORG\",         # Organizations, including companies, agencies, institutions\n",
+    "    \"GPE\",         # Geopolitical entities like countries, cities, states\n",
+    "    \"LOC\",         # Non-GPE locations, mountain ranges, bodies of water\n",
+    "    \"PRODUCT\",     # Vehicles, foods, appareal, appliances, software, toys (Not services.)\n",
+    "    \"EVENT\",       # Named sports, scientific milestones, historical events, etc\n",
+    "    \"WORK_OF_ART\", # Titles of books, songs, movies\n",
+    "    \"LAW\",         # Named laws, acts, or legislations\n",
+    "    \"LANGUAGE\",    # Any named language\n",
+    "    \"DATE\",        # Absolute or relative dates or periods\n",
+    "    \"TIME\",        # Times smaller than a day\n",
+    "    \"PERCENT\",     # Percentage (e.g., \"twenty percent\", \"18%\")\n",
+    "    \"MONEY\",       # Monetary values, including unit\n",
+    "    \"QUANTITY\",    # Measurements, e.g., weight or distance\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. Prepare Completion Messages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The OpenAI Chat completion models take a list of messages as input and return a model-generated message as output. Although the chat format is designed to make multi-turn conversations easy, it’s just as useful for single-turn tasks without any conversation. In our case, we will define three messages for the system, assistant and user roles."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The system message sets the behavior of the assistant by defining its persona and task:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def system_message(ner_labels):\n",
+    "    return f\"\"\"\n",
+    "            You are an expert in Natural Language Processing.\n",
+    "            You will be provided with a block of text. Your task is to identify and list common Named Entities (NER) by their type in the given text.\n",
+    "            The common Named Entities (NER) types are: ({\", \".join(ner_labels)}).\n",
+    "            Provide your output as a dictionary with entity types as keys, and lists of corresponding entities as values.\n",
+    "            \"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Assistant messages usually store previous assistant responses, but can also be written - as in our case - to give examples of desired behavior:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def assisstant_message():\n",
+    "    return f\"\"\"\n",
+    "            EXAMPLE:\n",
+    "                Text: 'In Germany, in 1440, goldsmith Johannes Gutenberg invented the movable-type printing press, which started the Printing Revolution. \n",
+    "                    Modelled on the design of existing screw presses, a single Renaissance movable-type printing press could produce up to 3,600 pages per workday'\n",
+    "                {{\n",
+    "                    \"GPE\": [\"germany\"],\n",
+    "                    \"DATE\": [\"1440\"],\n",
+    "                    \"PERSON\": [\"johannes gutenberg\"],\n",
+    "                    \"PRODUCT\": [\"movable-type printing press\"],\n",
+    "                    \"EVENT\": [\"printing revolution\",\"renaissance\"],\n",
+    "                    \"QUANTITY\": [\"3,600 pages\"],\n",
+    "                    \"TIME\": [\"workday\"]\n",
+    "                }}\n",
+    "            \"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The user message provides the request for the assistant to respond to:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def user_message(text):\n",
+    "    return f\"\"\"\n",
+    "            TASK:\n",
+    "                Text: {text}\n",
+    "            \"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4. ChatCompletion for Named Entity Recognition"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def named_entity_recognition(ner_labels, text):\n",
+    "    response = openai.ChatCompletion.create(\n",
+    "      model=OPENAI_MODEL, \n",
+    "      messages=[\n",
+    "          {\"role\": \"system\", \"content\": system_message(ner_labels=ner_labels)},\n",
+    "          {\"role\": \"assistant\", \"content\": assisstant_message()},\n",
+    "          {\"role\": \"user\", \"content\": user_message(text=text)}\n",
+    "      ],\n",
+    "      n=1,\n",
+    "      max_tokens=256,\n",
+    "      temperature=0,\n",
+    "      frequency_penalty=0,\n",
+    "      presence_penalty=0\n",
+    "    )\n",
+    "    \n",
+    "    return response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 4.1 Format Response "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_to_text(response):\n",
+    "    return response.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_to_dict(response):\n",
+    "    text = response.choices[0].message.content\n",
+    "    return json.loads(text.strip())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5. Sample Texts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 5.1. OpenAI Text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'stop'"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sample_text = \"\"\"OpenAI is an AI research and deployment company. Its mission is to ensure that artificial general intelligence benefits all of humanity.\n",
+    "                 OpenAI was founded in 2015 by Ilya Sutskever, Greg Brockman, Trevor Blackwell, Vicki Cheung, Andrej Karpathy, Durk Kingma, Jessica Livingston, \n",
+    "                 John Schulman, Pamela Vagata, and Wojciech Zaremba, with Sam Altman and Elon Musk serving as the initial board members. \n",
+    "                 Microsoft provided OpenAI with a $1 billion investment in 2019 and a $10 billion investment in 2023.\"\"\"\n",
+    "\n",
+    "response = named_entity_recognition(ner_labels=ner_labels, text=sample_text)\n",
+    "response.choices[0].finish_reason"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"ORG\": [\"OpenAI\", \"Microsoft\"],\n",
+      "    \"DATE\": [\"2015\", \"2019\", \"2023\"],\n",
+      "    \"PERSON\": [\"Ilya Sutskever\", \"Greg Brockman\", \"Trevor Blackwell\", \"Vicki Cheung\", \"Andrej Karpathy\", \"Durk Kingma\", \"Jessica Livingston\", \"John Schulman\", \"Pamela Vagata\", \"Wojciech Zaremba\", \"Sam Altman\", \"Elon Musk\"],\n",
+      "    \"MONEY\": [\"$1 billion\", \"$10 billion\"]\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(convert_to_text(response))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 5.2 Olympics Text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'stop'"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sample_text = \"\"\"The 1896 Summer Olympics, officially known as the Games of the Olympiad, was an international multi-sport event.\n",
+    "                 It was celebrated in Athens, Greece, from 6 to 15 April 1896.\n",
+    "                 About 100,000 people attended for the opening of the games. The athletes came from 14 nations, with most coming from Greece.\"\"\"\n",
+    "\n",
+    "response = named_entity_recognition(ner_labels=ner_labels, text=sample_text)\n",
+    "response.choices[0].finish_reason"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"DATE\": [\"1896\", \"6 to 15 April 1896\"],\n",
+      "    \"EVENT\": [\"summer olympics\", \"games of the olympiad\"],\n",
+      "    \"GPE\": [\"athens\", \"greece\", \"14 nations\", \"greece\"],\n",
+      "    \"QUANTITY\": [\"100,000 people\"]\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(convert_to_text(response))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 5.3 Format Response as Dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"DATE\": [\n",
+      "        \"1896\",\n",
+      "        \"6 to 15 April 1896\"\n",
+      "    ],\n",
+      "    \"EVENT\": [\n",
+      "        \"summer olympics\",\n",
+      "        \"games of the olympiad\"\n",
+      "    ],\n",
+      "    \"GPE\": [\n",
+      "        \"athens\",\n",
+      "        \"greece\",\n",
+      "        \"14 nations\",\n",
+      "        \"greece\"\n",
+      "    ],\n",
+      "    \"QUANTITY\": [\n",
+      "        \"100,000 people\"\n",
+      "    ]\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "ner_dict = convert_to_dict(response)\n",
+    "print(json.dumps(ner_dict, indent=4))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/registry.yaml
+++ b/registry.yaml
@@ -1021,6 +1021,14 @@
     - tiktoken
     - completions
 
+- title: Named Entity Recognition with ChatCompletion
+  path: examples/Named_Entity_Recognition.ipynb
+  date: 2023-10-09
+  authors:
+    - dcarpintero
+  tags:
+    - completions
+
 - title: What makes documentation good
   path: what_makes_documentation_good.md
   date: 2023-09-01


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#771](https://github.com/openai/openai-cookbook/pull/771)
> **Original author:** @dcarpintero
> **Originally opened:** 2023-10-09

---

## Summary

Add a notebook to perform Named Entity Recognition (NER) with the ChatCompletion endpoint.

## Motivation

Illustrate the use of system, assistant, and user messages with the ChatCompletion endpoint to perform the task of identifying and classifying Named Entities (NE) from a given text into predefined semantic categories.
