### PR TITLE
Correct legacy fine-tuning note

### DIFF
--- a/examples/Chat_finetuning_data_prep.ipynb
+++ b/examples/Chat_finetuning_data_prep.ipynb
@@ -10,8 +10,8 @@
     "\n",
     "This notebook serves as a tool to preprocess and analyze the chat dataset used for fine-tuning a chat model. \n",
     "It checks for format errors, provides basic statistics, and estimates token counts for fine-tuning costs.\n",
-    "The method shown here corresponds to [legacy fine-tuning](https://platform.openai.com/docs/guides/legacy-fine-tuning) for models like babbage-002 and davinci-002.\n",
-    "For fine-tuning gpt-3.5-turbo, see [the current fine-tuning page](https://platform.openai.com/docs/guides/fine-tuning)."
+    "The method shown here corresponds to the [current fine-tuning method](https://platform.openai.com/docs/guides/fine-tuning) for gpt-3.5-turbo.\n",
+    "See [legacy fine-tuning](https://platform.openai.com/docs/guides/legacy-fine-tuning) for models like babbage-002 and davinci-002."
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#770](https://github.com/openai/openai-cookbook/pull/770)
> **Original author:** @superfamousdog
> **Originally opened:** 2023-10-09

---

Correct legacy fine-tuning note

## Summary

I had the current and legacy links the wrong way round in my initial commit :( 

## Motivation

When navigating the documentation, it is helpful to know to which fine-tuning method the instructions apply

