### PR TITLE
Fix link to .py file

### DIFF
--- a/examples/How_to_handle_rate_limits.ipynb
+++ b/examples/How_to_handle_rate_limits.ipynb
@@ -586,7 +586,7 @@
    "source": [
     "## Example parallel processing script\n",
     "\n",
-    "We've written an example script for parallel processing large quantities of API requests: [api_request_parallel_processor.py](api_request_parallel_processor.py).\n",
+    "We've written an example script for parallel processing large quantities of API requests: [api_request_parallel_processor.py](https://github.com/openai/openai-cookbook/blob/main/examples/api_request_parallel_processor.py).\n",
     "\n",
     "The script combines some handy features:\n",
     "- Streams requests from file, to avoid running out of memory for giant jobs\n",


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#763](https://github.com/openai/openai-cookbook/pull/763)
> **Original author:** @cathykc
> **Originally opened:** 2023-10-05

---

## Summary

This link is currently broken on cookbook website - https://cookbook.openai.com/examples/how_to_handle_rate_limits (page end)

It's a relative link but cookbook website currently does not support `.py` files.

## Changes

Updating to point to Github URL
