### PR TITLE
Fix spelling error + misplaced copypaste in the CQL notebook

### DIFF
--- a/examples/vector_databases/cassandra_astradb/Philosophical_Quotes_CQL.ipynb
+++ b/examples/vector_databases/cassandra_astradb/Philosophical_Quotes_CQL.ipynb
@@ -201,7 +201,7 @@
    "outputs": [],
    "source": [
     "# Don't mind the \"Closing connection\" error after \"downgrading protocol...\" messages,\n",
-    "# it is really just a warning: the connection will work smoothly.cluster = Cluster(\n",
+    "# it is really just a warning: the connection will work smoothly.\n",
     "cluster = Cluster(\n",
     "    cloud={\n",
     "        \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
@@ -280,7 +280,7 @@
    "id": "2c1be40d-bb6f-46d1-b39a-ac51ce11a466",
    "metadata": {},
    "source": [
-    "#### Add an vector index for ANN search"
+    "#### Add a vector index for ANN search"
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#728](https://github.com/openai/openai-cookbook/pull/728)
> **Original author:** @hemidactylus
> **Originally opened:** 2023-09-20

---

This is very minor, just aesthetic fixes. Thank you!
