### PR TITLE
Elasticsearch: fix typo in signup url

### DIFF
--- a/examples/vector_databases/elasticsearch/elasticsearch-retrieval-augmented-generation.ipynb
+++ b/examples/vector_databases/elasticsearch/elasticsearch-retrieval-augmented-generation.ipynb
@@ -879,7 +879,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.12"
   },
   "vscode": {
    "interpreter": {

--- a/examples/vector_databases/elasticsearch/elasticsearch-retrieval-augmented-generation.ipynb
+++ b/examples/vector_databases/elasticsearch/elasticsearch-retrieval-augmented-generation.ipynb
@@ -68,7 +68,7 @@
     "## Connect to Elasticsearch\n",
     "\n",
     "ℹ️ We're using an Elastic Cloud deployment of Elasticsearch for this notebook.\n",
-    "If you don't already have an Elastic deployment, you can sign up for a free [Elastic Cloud trial](https://cloud.elastic.co/registration?fromURI=%2Fhome).\n",
+    "If you don't already have an Elastic deployment, you can sign up for a free [Elastic Cloud trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=openai-cookbook).\n",
     "\n",
     "To connect to Elasticsearch, you need to create a client instance with the Cloud ID and password for your deployment.\n",
     "\n",
@@ -879,7 +879,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.4"
   },
   "vscode": {
    "interpreter": {

--- a/examples/vector_databases/elasticsearch/elasticsearch-semantic-search.ipynb
+++ b/examples/vector_databases/elasticsearch/elasticsearch-semantic-search.ipynb
@@ -65,7 +65,7 @@
     "## Connect to Elasticsearch\n",
     "\n",
     "ℹ️ We're using an Elastic Cloud deployment of Elasticsearch for this notebook.\n",
-    "If you don't already have an Elastic deployment, you can sign up for a free [Elastic Cloud trial](https://cloud.elastic.co/registration?fromURI=%2Fhome).\n",
+    "If you don't already have an Elastic deployment, you can sign up for a free [Elastic Cloud trial](https://cloud.elastic.co/registration?utm_source=github&utm_content=openai-cookbook).\n",
     "\n",
     "To connect to Elasticsearch, you need to create a client instance with the Cloud ID and password for your deployment.\n",
     "\n",
@@ -803,7 +803,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.4"
   },
   "vscode": {
    "interpreter": {

--- a/examples/vector_databases/elasticsearch/elasticsearch-semantic-search.ipynb
+++ b/examples/vector_databases/elasticsearch/elasticsearch-semantic-search.ipynb
@@ -803,7 +803,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.12"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#726](https://github.com/openai/openai-cookbook/pull/726)
> **Original author:** @saarikabhasi
> **Originally opened:** 2023-09-19

---

## PR Summary

This PR fixes Elastic Cloud sign up url in Elasticsearch Vector Database example [notebooks](https://github.com/openai/openai-cookbook/tree/main/examples/vector_databases/elasticsearch)
