### PR TITLE
Add Haystack to Prompting libraries & tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Most code examples are written in Python, though the concepts can be applied in 
 
 For other useful tools, guides and courses, check out these [related resources from around the web](https://cookbook.openai.com/related_resources).
 
-
 ## Contributing
 
 The contents of this repo are automatically rendered into [cookbook.openai.com](https://cookbook.openai.com). If there are examples or guides you'd like to see, feel free to suggest them on the [issues page](https://github.com/openai/openai-cookbook/issues). We are also happy to accept high quality pull requests, as long as they fit the scope of the cookbook.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Most code examples are written in Python, though the concepts can be applied in 
 
 For other useful tools, guides and courses, check out these [related resources from around the web](https://cookbook.openai.com/related_resources).
 
+
 ## Contributing
 
 The contents of this repo are automatically rendered into [cookbook.openai.com](https://cookbook.openai.com). If there are examples or guides you'd like to see, feel free to suggest them on the [issues page](https://github.com/openai/openai-cookbook/issues). We are also happy to accept high quality pull requests, as long as they fit the scope of the cookbook.

--- a/related_resources.md
+++ b/related_resources.md
@@ -21,6 +21,7 @@ People are writing great tools and papers for improving outputs from GPT. Here a
 - [LlamaIndex](https://github.com/jerryjliu/llama_index): A Python library for augmenting LLM apps with data.
 - [Arthur Shield](https://www.arthur.ai/get-started): A paid product for detecting toxicity, hallucination, prompt injection, etc.
 - [LMQL](https://lmql.ai): A programming language for LLM interaction with support for typed prompting, control flow, constraints, and tools.
+- [Haystack](https://github.com/deepset-ai/haystack): Open-source LLM orchestration framework to build customizable, production-ready LLM applications in Python.
 
 ## Prompting guides
 


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#682](https://github.com/openai/openai-cookbook/pull/682)
> **Original author:** @anakin87
> **Originally opened:** 2023-09-05

---

Hello!

[Haystack](https://github.com/deepset-ai/haystack) is a popular Python LLM orchestration framework.
It supports OpenAI models for text generation and embeddings.

It would be nice to add it to the "Prompting libraries & tools" section...
