### PR TITLE
Corrected spelling mistake in Search_reranking_with_cross-encoders.ipynb

### DIFF
--- a/examples/Search_reranking_with_cross-encoders.ipynb
+++ b/examples/Search_reranking_with_cross-encoders.ipynb
@@ -178,7 +178,7 @@
     "\n",
     "The steps here are:\n",
     "- Build a prompt to assess relevance and provide few-shot examples to tune it to your domain.\n",
-    "- Add a ```logit bias``` for the tokens for ``` Yes``` and ``` No``` to decrease the likelihood of any o.ther tokens occurring.\n",
+    "- Add a ```logit bias``` for the tokens for ``` Yes``` and ``` No``` to decrease the likelihood of any other tokens occurring.\n",
     "- Return the classification of yes/no as well as the ```logprobs```.\n",
     "- Rerank the results by the ```logprobs``` keyed on ``` Yes```."
    ]


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#675](https://github.com/openai/openai-cookbook/pull/675)
> **Original author:** @pdshorthills
> **Originally opened:** 2023-09-04

---

I was going through this documentation and found this error. Hope my little contribution will be added.
