### PR TITLE
Add liteLLM Example - Call Azure, Anthropic, Llama2, Cohere, 50+ LLM APIs using chatGPT input/output

### DIFF
--- a/examples/third_party_examples/liteLLM_OpenAI.ipynb
+++ b/examples/third_party_examples/liteLLM_OpenAI.ipynb
@@ -1,0 +1,341 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## 🚅 liteLLM Demo\n",
+        "### TLDR: Call 50+ LLM APIs using chatGPT Input/Output format\n",
+        "https://github.com/BerriAI/litellm\n",
+        "\n",
+        "liteLLM is package to simplify calling **OpenAI, Azure, Llama2, Cohere, Anthropic, Huggingface API Endpoints**. LiteLLM manages\n",
+        "\n",
+        "* Translating inputs to the provider's `completion()` and `embedding()` endpoints\n",
+        "* Guarantees consistent output, text responses will always be available at `['choices'][0]['message']['content']`\n",
+        "* Exception mapping - common exceptions across providers are mapped to the OpenAI exception types\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "MZ01up0p7wOJ"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Installation and setting Params"
+      ],
+      "metadata": {
+        "id": "RZtzCnQS7rW-"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "rsrN5W-N7L8d"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install litellm"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from litellm import completion\n",
+        "import os"
+      ],
+      "metadata": {
+        "id": "ArrWyG5b7QAG"
+      },
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Set your API keys\n",
+        "- liteLLM reads your .env, env variables or key manager for Auth"
+      ],
+      "metadata": {
+        "id": "bbhJRt34_NJ1"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "os.environ['OPENAI_API_KEY'] = \"\" #@param\n",
+        "os.environ[\"ANTHROPIC_API_KEY\"] = \"\" #@param\n",
+        "os.environ[\"AZURE_API_BASE\"] = \"\" #@param\n",
+        "os.environ[\"AZURE_API_VERSION\"] = \"\" #@param\n",
+        "os.environ[\"AZURE_API_KEY\"] = \"\" #@param\n",
+        "os.environ[\"REPLICATE_API_TOKEN\"] = \"\" #@param\n",
+        "os.environ[\"COHERE_API_KEY\"] = \"\" #@param\n",
+        "os.environ[\"HF_TOKEN\"] = \"\" #@param"
+      ],
+      "metadata": {
+        "id": "-h8Ga5cR7SvV"
+      },
+      "execution_count": 23,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "messages = [{ \"content\": \"what's the weather in SF\",\"role\": \"user\"}]"
+      ],
+      "metadata": {
+        "id": "MBujGiby8YBu"
+      },
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Call chatGPT"
+      ],
+      "metadata": {
+        "id": "fhqpKv6L8fBj"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "completion(model=\"gpt-3.5-turbo\", messages=messages)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "speIkoX_8db4",
+        "outputId": "bc804d62-1d33-4198-b6d7-b721961694a3"
+      },
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<OpenAIObject chat.completion id=chatcmpl-7mrklZEq2zK3Z5pSkOR3Jn54gpN5A at 0x7f76df70e930> JSON: {\n",
+              "  \"id\": \"chatcmpl-7mrklZEq2zK3Z5pSkOR3Jn54gpN5A\",\n",
+              "  \"object\": \"chat.completion\",\n",
+              "  \"created\": 1691880727,\n",
+              "  \"model\": \"gpt-3.5-turbo-0613\",\n",
+              "  \"choices\": [\n",
+              "    {\n",
+              "      \"index\": 0,\n",
+              "      \"message\": {\n",
+              "        \"role\": \"assistant\",\n",
+              "        \"content\": \"I'm sorry, but as an AI language model, I don't have real-time data. However, you can check the current weather in San Francisco by using a weather website or app, or by searching \\\"weather in San Francisco\\\" on a search engine.\"\n",
+              "      },\n",
+              "      \"finish_reason\": \"stop\"\n",
+              "    }\n",
+              "  ],\n",
+              "  \"usage\": {\n",
+              "    \"prompt_tokens\": 13,\n",
+              "    \"completion_tokens\": 52,\n",
+              "    \"total_tokens\": 65\n",
+              "  }\n",
+              "}"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 9
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Call Claude-2"
+      ],
+      "metadata": {
+        "id": "Q3jV1Uxv8zNo"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "completion(model=\"claude-2\", messages=messages)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "V8yTWYzY8m9S",
+        "outputId": "8b6dd32d-f9bf-4e89-886d-47cb8020f025"
+      },
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "{'choices': [{'finish_reason': 'stop',\n",
+              "   'index': 0,\n",
+              "   'message': {'role': 'assistant',\n",
+              "    'content': \" Unfortunately I do not have enough context to provide the current weather in San Francisco. To get the most accurate weather report, it's helpful if I know details like:\\n\\n- Exact location (city name, zip code, etc)\\n- Time frame (current conditions, forecast for a certain day/week, etc)\\n\\nIf you can provide some more specifics about what weather information you need for San Francisco, I'd be happy to look that up for you!\"}}],\n",
+              " 'created': 1691880836.974166,\n",
+              " 'model': 'claude-2',\n",
+              " 'usage': {'prompt_tokens': 18, 'completion_tokens': 95, 'total_tokens': 113}}"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 11
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Call llama2 on replicate"
+      ],
+      "metadata": {
+        "id": "yu0LPDmW9PJa"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "model = \"replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1\"\n",
+        "completion(model=model, messages=messages)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "0GWV5mtO9Jbu",
+        "outputId": "38538825-b271-406d-a437-f5cf0eb7e548"
+      },
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "{'choices': [{'finish_reason': 'stop',\n",
+              "   'index': 0,\n",
+              "   'message': {'role': 'assistant',\n",
+              "    'content': ' I\\'m happy to help! However, I must point out that the question \"what\\'s the weather in SF\" doesn\\'t make sense as \"SF\" could refer to multiple locations (San Francisco, South Florida, San Fernando, etc.). Could you please provide more context or specify which location you\\'re referring to? That way, I can give you an accurate answer.'}}],\n",
+              " 'created': 1691880930.9003325,\n",
+              " 'model': 'replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1',\n",
+              " 'usage': {'prompt_tokens': 6, 'completion_tokens': 74, 'total_tokens': 80}}"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 13
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Call Command-Nightly"
+      ],
+      "metadata": {
+        "id": "HXdj5SEe9iLK"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "completion(model=\"command-nightly\", messages=messages)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "EaUq2xIx9fhr",
+        "outputId": "55fe6f52-b58b-4729-948a-74dac4b431b2"
+      },
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "{'choices': [{'finish_reason': 'stop',\n",
+              "   'index': 0,\n",
+              "   'message': {'role': 'assistant',\n",
+              "    'content': ' The weather in San Francisco can be quite unpredictable. The city is known for its fog, which can'}}],\n",
+              " 'created': 1691880972.5565543,\n",
+              " 'model': 'command-nightly',\n",
+              " 'usage': {'prompt_tokens': 6, 'completion_tokens': 20, 'total_tokens': 26}}"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 15
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Call Azure OpenAI"
+      ],
+      "metadata": {
+        "id": "1g9hSgsL9soJ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "completion(deployment_id=\"chatgpt-test\", messages=messages, azure=True)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "AvLjR-PF-lt0",
+        "outputId": "deff2db3-b003-48cd-ea62-c03a68a4464a"
+      },
+      "execution_count": 24,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<OpenAIObject chat.completion id=chatcmpl-7mrtwvpx3okijXmbt9PEYdPMeE7lH at 0x7f76cfb356c0> JSON: {\n",
+              "  \"id\": \"chatcmpl-7mrtwvpx3okijXmbt9PEYdPMeE7lH\",\n",
+              "  \"object\": \"chat.completion\",\n",
+              "  \"created\": 1691881296,\n",
+              "  \"model\": \"gpt-35-turbo\",\n",
+              "  \"choices\": [\n",
+              "    {\n",
+              "      \"index\": 0,\n",
+              "      \"finish_reason\": \"stop\",\n",
+              "      \"message\": {\n",
+              "        \"role\": \"assistant\",\n",
+              "        \"content\": \"I'm sorry, as an AI language model, I don't have real-time data. However, you can check the weather forecast for San Francisco on websites such as AccuWeather or Weather Channel.\"\n",
+              "      }\n",
+              "    }\n",
+              "  ],\n",
+              "  \"usage\": {\n",
+              "    \"completion_tokens\": 40,\n",
+              "    \"prompt_tokens\": 14,\n",
+              "    \"total_tokens\": 54\n",
+              "  }\n",
+              "}"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 24
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#633](https://github.com/openai/openai-cookbook/pull/633)
> **Original author:** @ishaan-jaff
> **Originally opened:** 2023-08-12

---

This PR adds an example notebook of using liteLLM: https://github.com/BerriAI/litellm/

liteLLM is a package to simplify calling OpenAI, Azure, Cohere, Anthropic, Huggingface API Endpoints
**TLDR: Call all LLM APIs using chatGPT input/output formats**

Here's a sample of how it's used:

```
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# llama2 call
model_name = "replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1"
response = completion(model_name, messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```
