### PR TITLE
Add Tiktokenizer link in "How to count tokens"

### DIFF
--- a/examples/How_to_count_tokens_with_tiktoken.ipynb
+++ b/examples/How_to_count_tokens_with_tiktoken.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "## How strings are typically tokenized\n",
     "\n",
-    "In English, tokens commonly range in length from one character to one word (e.g., `\"t\"` or `\" great\"`), though in some languages tokens can be shorter than one character or longer than one word. Spaces are usually grouped with the starts of words (e.g., `\" is\"` instead of `\"is \"` or `\" \"`+`\"is\"`). You can quickly check how a string is tokenized at the [OpenAI Tokenizer](https://beta.openai.com/tokenizer)."
+    "In English, tokens commonly range in length from one character to one word (e.g., `\"t\"` or `\" great\"`), though in some languages tokens can be shorter than one character or longer than one word. Spaces are usually grouped with the starts of words (e.g., `\" is\"` instead of `\"is \"` or `\" \"`+`\"is\"`). You can quickly check how a string is tokenized at the [OpenAI Tokenizer](https://beta.openai.com/tokenizer), or the third-party [Tiktokenizer](https://tiktokenizer.vercel.app/) webapp."
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#604](https://github.com/openai/openai-cookbook/pull/604)
> **Original author:** @EliahKagan
> **Originally opened:** 2023-07-24

---

This adds a link to the popular [Tiktokenizer](https://tiktokenizer.vercel.app/) webapp, in the section of the "How to count tokens with tiktoken" notebook that talks about the [OpenAI Tokenizer](https://platform.openai.com/tokenizer). It retains the reference to the OpenAI Tokenizer as well.

Rationale:

- The [tiktoken FAQ](https://github.com/openai/tiktoken/issues/98) recommends Tiktokenizer as a resource, in the first line under "Usage help". Besides indicating that it is a helpful resource, this also suggests that OpenAI is already willing to direct users to it.
- Tiktokenizer supports some important encodings the OpenAI Tokenizer currently does not, such as cl100k_base. This allows users to see how text is tokenized for chat models like gpt-3.5-turbo and gpt-4, and for the embedding model text-embedding-ada-002. In contrast, the OpenAI Tokenizer currently only supports GPT-3 and Codex.

(I am not affiliated in any way with Tiktokenizer. I learned about it a while ago from the tiktoken FAQ, and I've often found it useful.)

I'm unsure what the best wording is here, but I phrased it "or the third-party Tiktokenizer webapp" to so no readers are misled into thinking Tiktokenizer is itself developed by OpenAI.
