### PR TITLE
fix bug in function group_chunks which not reset cur_tokens

### DIFF
--- a/examples/book_translation/translate_latex_book.ipynb
+++ b/examples/book_translation/translate_latex_book.ipynb
@@ -130,7 +130,6 @@
     "        if ntoken + cur_tokens > max_len:\n",
     "            batches.append(cur_batch)\n",
     "            cur_batch = chunk\n",
-    "            cur_batch = chunk\n",
     "            cur_tokens = ntoken\n",
     "        else:\n",
     "            cur_batch += \"\\n\\n\" + chunk\n",

--- a/examples/book_translation/translate_latex_book.ipynb
+++ b/examples/book_translation/translate_latex_book.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -12,6 +13,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -47,6 +49,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -85,6 +88,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -126,6 +130,8 @@
     "        if ntoken + cur_tokens > max_len:\n",
     "            batches.append(cur_batch)\n",
     "            cur_batch = chunk\n",
+    "            cur_batch = chunk\n",
+    "            cur_tokens = ntoken\n",
     "        else:\n",
     "            cur_batch += \"\\n\\n\" + chunk\n",
     "    batches.append(cur_batch)\n",
@@ -136,6 +142,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -228,6 +235,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#559](https://github.com/openai/openai-cookbook/pull/559)
> **Original author:** @dhrim
> **Originally opened:** 2023-07-01

---

Reset code was missing during iteration.

I just inserted reset code in iteration.
