### PR TITLE
update to token for zilliz

### DIFF
--- a/examples/vector_databases/Using_vector_databases_for_embeddings_search.ipynb
+++ b/examples/vector_databases/Using_vector_databases_for_embeddings_search.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "cb1537e6",
    "metadata": {},
@@ -59,6 +60,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e2b59250",
    "metadata": {},
@@ -138,6 +140,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e5d9d2e1",
    "metadata": {},
@@ -218,6 +221,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "81bf5349",
    "metadata": {},
@@ -233,6 +237,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "37d1f693",
    "metadata": {},
@@ -266,6 +271,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5cd61943",
    "metadata": {},
@@ -307,6 +313,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "02887b52",
    "metadata": {},
@@ -339,6 +346,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "79122c6b",
    "metadata": {},
@@ -400,6 +408,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a03e7645",
    "metadata": {},
@@ -408,6 +417,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ed32fc87",
    "metadata": {},
@@ -436,6 +446,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "63b28543",
    "metadata": {},
@@ -539,6 +550,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2da40a69",
    "metadata": {},
@@ -627,6 +639,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d939342f",
    "metadata": {},
@@ -657,6 +670,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "bfdfe260",
    "metadata": {},
@@ -721,6 +735,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "03a926b9",
    "metadata": {},
@@ -866,6 +881,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "46050ca9",
    "metadata": {},
@@ -933,6 +949,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "220b3e11",
    "metadata": {},
@@ -1005,6 +1022,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4dc3a0c0",
    "metadata": {},
@@ -1021,6 +1039,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "fe4914e9",
    "metadata": {},
@@ -1046,6 +1065,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "64ffed22",
    "metadata": {},
@@ -1146,6 +1166,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1f68a790",
    "metadata": {},
@@ -1230,11 +1251,10 @@
     "from pymilvus import connections\n",
     "\n",
     "uri = os.getenv(\"ZILLIZ_URI\")\n",
-    "user = os.getenv(\"ZILLIZ_USER\")\n",
-    "password = os.getenv(\"ZILLIZ_PASSWORD\")\n",
+    "token = os.getenv(\"ZILLIZ_TOKEN\") # TOKEN == user:password or api_key\n",
     "if connections.has_connection('default'):\n",
     "    connections.disconnect('default')\n",
-    "connections.connect(uri=uri, user=user, password=password, secure=True)"
+    "connections.connect(uri=uri, token=token)"
    ]
   },
   {
@@ -1383,6 +1403,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9cfaed9d",
    "metadata": {},
@@ -1398,6 +1419,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "38774565",
    "metadata": {},
@@ -1440,6 +1462,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "bc006b6f",
    "metadata": {},
@@ -1540,6 +1563,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "06ed119b",
    "metadata": {},
@@ -1616,6 +1640,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "43bffd04",
    "metadata": {},
@@ -1670,6 +1695,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "698e24f6",
    "metadata": {},
@@ -1723,6 +1749,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3f6f0af9",
    "metadata": {},
@@ -1801,6 +1828,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f3563eec",
    "metadata": {},
@@ -1845,6 +1873,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f646bff4",
    "metadata": {},
@@ -1921,6 +1950,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0ed0b34e",
    "metadata": {},
@@ -1978,6 +2008,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f94b5be2",
    "metadata": {},
@@ -1986,6 +2017,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false
@@ -2001,6 +2033,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false
@@ -2038,6 +2071,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false
@@ -2145,6 +2179,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false
@@ -2250,6 +2285,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "55afccbf",
    "metadata": {},
@@ -2258,6 +2294,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "56a02772",
    "metadata": {},
@@ -2271,6 +2308,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d3e1f96b",
    "metadata": {},
@@ -2294,6 +2332,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "067009db",
    "metadata": {},
@@ -2346,6 +2385,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b0f0e591",
    "metadata": {},
@@ -2369,6 +2409,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "fe55234a",
    "metadata": {},

--- a/examples/vector_databases/zilliz/Filtered_search_with_Zilliz_and_OpenAI.ipynb
+++ b/examples/vector_databases/zilliz/Filtered_search_with_Zilliz_and_OpenAI.ipynb
@@ -53,8 +53,7 @@
     "import openai\n",
     "\n",
     "URI = 'your_uri'\n",
-    "USER = 'your_user'\n",
-    "PASSWORD = 'your_password'\n",
+    "TOKEN = 'your_token' # TOKEN == user:password or api_key\n",
     "COLLECTION_NAME = 'book_search'\n",
     "DIMENSION = 1536\n",
     "OPENAI_ENGINE = 'text-embedding-ada-002'\n",
@@ -83,7 +82,7 @@
     "from pymilvus import connections, utility, FieldSchema, Collection, CollectionSchema, DataType\n",
     "\n",
     "# Connect to Zilliz Database\n",
-    "connections.connect(uri=URI, user=USER, password=PASSWORD, secure=True)"
+    "connections.connect(uri=URI, token=TOKEN)"
    ]
   },
   {

--- a/examples/vector_databases/zilliz/Getting_started_with_Zilliz_and_OpenAI.ipynb
+++ b/examples/vector_databases/zilliz/Getting_started_with_Zilliz_and_OpenAI.ipynb
@@ -99,8 +99,7 @@
     "import openai\n",
     "\n",
     "URI = 'your_uri'\n",
-    "USER = 'your_user'\n",
-    "PASSWORD = 'your_password'\n",
+    "TOKEN = 'your_token' # TOKEN == user:password or api_key\n",
     "COLLECTION_NAME = 'book_search'\n",
     "DIMENSION = 1536\n",
     "OPENAI_ENGINE = 'text-embedding-ada-002'\n",
@@ -138,7 +137,7 @@
     "from pymilvus import connections, utility, FieldSchema, Collection, CollectionSchema, DataType\n",
     "\n",
     "# Connect to Zilliz Database\n",
-    "connections.connect(uri=URI, user=USER, password=PASSWORD, secure=True)"
+    "connections.connect(uri=URI, token=TOKEN)"
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#552](https://github.com/openai/openai-cookbook/pull/552)
> **Original author:** @filip-halt
> **Originally opened:** 2023-06-27

---

Updating the zilliz notebooks to use a token instead of username and password. Required for it to work with current cloud. 
