### PR TITLE
Fix typo in Question_answering_using_a_search_API.ipynb

### DIFF
--- a/examples/Question_answering_using_a_search_API.ipynb
+++ b/examples/Question_answering_using_a_search_API.ipynb
@@ -315,7 +315,7 @@
    ],
    "source": [
     "HA_INPUT = f\"\"\"\n",
-    "Generate a hypothetical answer to the user's question. This answer which will be used to rank search results. \n",
+    "Generate a hypothetical answer to the user's question. This answer will be used to rank search results. \n",
     "Pretend you have all the information you need to answer, but don't use any actual facts. Instead, use placeholders\n",
     "like NAME did something, or NAME said something at PLACE. \n",
     "\n",


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#539](https://github.com/openai/openai-cookbook/pull/539)
> **Original author:** @spqw
> **Originally opened:** 2023-06-22

---

"This answer which will be used to..." --> "This answer will be used to..."
