### PR TITLE
Add parea to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ People are writing great tools and papers for improving outputs from GPT. Here a
 - [Chainlit](https://docs.chainlit.io/overview): A Python library for making chatbot interfaces.
 - [Guardrails.ai](https://shreyar.github.io/guardrails/): A Python library for validating outputs and retrying failures. Still in alpha, so expect sharp edges and bugs.
 - [Semantic Kernel](https://devblogs.microsoft.com/semantic-kernel/): A Python/C# library from Microsoft that supports prompt templating, function chaining, vectorized memory, and intelligent planning.
+- [Parea AI](https://www.parea.ai): A platform for testing, improving, and managing prompts.
 - [Outlines](https://github.com/normal-computing/outlines): A Python library that provides a domain-specific language to simplify prompting and constrain generation.
 - [Promptify](https://github.com/promptslab/Promptify): A small Python library for using language models to perform NLP tasks.
 - [Scale Spellbook](https://scale.com/spellbook): A paid product for building, comparing, and shipping language model apps.


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#507](https://github.com/openai/openai-cookbook/pull/507)
> **Original author:** @joschkabraun
> **Originally opened:** 2023-06-14

---

Included [Parea AI](https://www.parea.ai) (previously, OptimusPrompt) as a tool under resources. It provides advanced auto-prompt engineering techniques, as well as allows testing and versioning of prompts.

![234576426-46d80c9a-c258-4809-af69-78d2fa926a94](https://github.com/openai/openai-cookbook/assets/47435119/89b22f1b-57ba-47c1-a33f-3de3b694c8ac)
