### PR TITLE
fix label 'contradiction' dropped bug

### DIFF
--- a/examples/Customizing_embeddings.ipynb
+++ b/examples/Customizing_embeddings.ipynb
@@ -84,7 +84,7 @@
         "    # you can customize this to preprocess your own dataset\n",
         "    # output should be a dataframe with 3 columns: text_1, text_2, label (1 for similar, -1 for dissimilar)\n",
         "    df[\"label\"] = df[\"gold_label\"]\n",
-        "    df = df[df[\"label\"].isin([\"entailment\"])]\n",
+        "    df = df[df[\"label\"].isin([\"entailment\", \"contradiction\"])]\n",
         "    df[\"label\"] = df[\"label\"].apply(lambda x: {\"entailment\": 1, \"contradiction\": -1}[x])\n",
         "    df = df.rename(columns={\"sentence1\": \"text_1\", \"sentence2\": \"text_2\"})\n",
         "    df = df[[\"text_1\", \"text_2\", \"label\"]]\n",


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#452](https://github.com/openai/openai-cookbook/pull/452)
> **Original author:** @dhrim
> **Originally opened:** 2023-05-24

---

in function process_input_data() label "contradiction" was missed when filtering "entailment" or "contradiction".
So all data was only of label "entailment"

I just added "contradition".

