### PR TITLE
Fix formidable 2.1.1 compatibility

### DIFF
--- a/apps/file-q-and-a/nextjs/src/pages/api/process-file.ts
+++ b/apps/file-q-and-a/nextjs/src/pages/api/process-file.ts
@@ -26,8 +26,10 @@ export default async function handler(
   }
 
   // Create a formidable instance to parse the request as a multipart form
-  const form = new formidable.IncomingForm();
-  form.maxFileSize = 30 * 1024 * 1024; // Set the max file size to 30MB
+  const form = new formidable.IncomingForm({
+    maxFileSize: 30 * 1024 * 1024
+  });
+  // Set the max file size to 30MB
 
   try {
     const { fields, files } = await new Promise<{


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#426](https://github.com/openai/openai-cookbook/pull/426)
> **Original author:** @KaimingTao
> **Originally opened:** 2023-05-16

---

The `file-q-and-a` application is not compatible to the current `formidable.js 2.1.1` library. The error occurs when running `npm run build`.
