### PR TITLE
Fix File Q&A build error due to removed way of assigning options to the Formidable instance

### DIFF
--- a/apps/file-q-and-a/nextjs/src/pages/api/process-file.ts
+++ b/apps/file-q-and-a/nextjs/src/pages/api/process-file.ts
@@ -26,7 +26,10 @@ export default async function handler(
   }
 
   // Create a formidable instance to parse the request as a multipart form
-  const form = new formidable.IncomingForm({maxFileSize: 30 * 1024 * 1024}); // Set the max file size to 30MB
+  const options = {
+    maxFileSize: 30 * 1024 * 1024 // Set the max file size to 30MB
+  }; 
+  const form = formidable(options);
 
   try {
     const { fields, files } = await new Promise<{

--- a/apps/file-q-and-a/nextjs/src/pages/api/process-file.ts
+++ b/apps/file-q-and-a/nextjs/src/pages/api/process-file.ts
@@ -26,8 +26,7 @@ export default async function handler(
   }
 
   // Create a formidable instance to parse the request as a multipart form
-  const form = new formidable.IncomingForm();
-  form.maxFileSize = 30 * 1024 * 1024; // Set the max file size to 30MB
+  const form = new formidable.IncomingForm({maxFileSize: 30 * 1024 * 1024}); // Set the max file size to 30MB
 
   try {
     const { fields, files } = await new Promise<{


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#372](https://github.com/openai/openai-cookbook/pull/372)
> **Original author:** @jerichosy
> **Originally opened:** 2023-04-25

---

Assigning a property value through `form.maxFileSize` directly no longer works and will result in `Type error: Property 'maxFileSize' does not exist on type 'IncomingForm'` during compilation when doing `npm run build`.

Instead, pass [`options`](https://github.com/node-formidable/formidable/blob/e5e25d2fd9a018c14d7f0014f0a9b8493892b68b/README.md#options) to the function/constructor as recommended by the [Formidable docs](https://github.com/node-formidable/formidable/blob/e5e25d2fd9a018c14d7f0014f0a9b8493892b68b/README.md#formidable--incomingform). 
