### PR TITLE
Update setup section to install openai module

### DIFF
--- a/examples/vector_databases/Using_vector_databases_for_embeddings_search.ipynb
+++ b/examples/vector_databases/Using_vector_databases_for_embeddings_search.ipynb
@@ -81,8 +81,11 @@
     "!pip install redis\n",
     "!pip install typesense\n",
     "\n",
-    "#Install wget to pull zip file\n",
-    "!pip install wget"
+    "# Install wget to pull zip file\n",
+    "!pip install wget",
+    "\n",
+    "# Install openai\n",
+    "!pip install openai"
    ]
   },
   {


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#340](https://github.com/openai/openai-cookbook/pull/340)
> **Original author:** @roncrivera
> **Originally opened:** 2023-04-14

---

The openai module is not part of the setup instructions and as such the subsequent imports fail.

This PR updates the setup section to include the installation of the openai python module.
