### PR TITLE
num_tokens_from_messages off by 1 token count

### DIFF
--- a/examples/How_to_format_inputs_to_ChatGPT_models.ipynb
+++ b/examples/How_to_format_inputs_to_ChatGPT_models.ipynb
@@ -459,7 +459,7 @@
     "                num_tokens += len(encoding.encode(value))\n",
     "                if key == \"name\":  # if there's a name, the role is omitted\n",
     "                    num_tokens += -1  # role is always required and always 1 token\n",
-    "        num_tokens += 2  # every reply is primed with <im_start>assistant\n",
+    "        num_tokens += 3  # every reply is primed with <im_start>assistant\n",
     "        return num_tokens\n",
     "    else:\n",
     "        raise NotImplementedError(f\"\"\"num_tokens_from_messages() is not presently implemented for model {model}.\n",


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#243](https://github.com/openai/openai-cookbook/pull/243)
> **Original author:** @jwchang0206
> **Originally opened:** 2023-03-18

---

Today I found that the calculation was wrong when I was calculating the token size for `gpt-3.5-turbo`
