### PR TITLE
Add example: improving embeddings sequences with lowpass filtering

### DIFF
--- a/examples/Improving_embeddings_with_signal_processing.ipynb
+++ b/examples/Improving_embeddings_with_signal_processing.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Improving embeddings with Signal Processing\n",
+    "\n",
+    "The canonical way of getting embeddings that encode more text than can fit in the embeddings models' context length is chunking the text, embedding each separately, then averaging in the time domain (see Cookbook notebook [here](https://github.com/openai/openai-cookbook/blob/main/examples/Embedding_long_inputs.ipynb)). However, better performance can be achieved if you transpose the embeddings to the frequency domain, use a signal processing technique like a lowpass filter to remove noise, transpose back to the time domain, and *then* average the embeddings in the time domain.\n",
+    "\n",
+    "This notebook demonstrates how to do this on an example document classification task.\n",
+    "\n",
+    "For more information, [read the paper here](https://jagilley.github.io/fft-embed.html).\n",
+    "\n",
+    "Utilities for implementing this method more simply can be found in [this GitHub repo](https://github.com/jagilley/fft-embeddings)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nltk.corpus import reuters\n",
+    "import openai\n",
+    "from tqdm import tqdm\n",
+    "import numpy as np\n",
+    "from openai.embeddings_utils import get_embeddings\n",
+    "from sklearn.neural_network import MLPClassifier\n",
+    "from sklearn.metrics import accuracy_score\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "import pickle\n",
+    "import librosa\n",
+    "import nltk\n",
+    "\n",
+    "# download nltk's reuters corpus\n",
+    "nltk.download('reuters')\n",
+    "\n",
+    "trade_docs = reuters.fileids(categories='trade')\n",
+    "crude_docs = reuters.fileids(categories='crude')\n",
+    "\n",
+    "all_docs = [reuters.raw(doc_id) for doc_id in trade_docs + crude_docs]\n",
+    "all_labels = ['trade' for _ in trade_docs] + ['crude' for _ in crude_docs]\n",
+    "\n",
+    "# shuffle docs and labels together\n",
+    "np.random.seed(42)\n",
+    "combined = list(zip(all_docs, all_labels))\n",
+    "np.random.shuffle(combined)\n",
+    "all_docs, all_labels = zip(*combined)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Traditional text classification: embed the entire document at once, then train an `MLPClassifier` to classify them"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Getting embeddings...')\n",
+    "EMBEDDINGS_ENGINE = \"text-embedding-ada-002\"\n",
+    "all_embeddings = get_embeddings(all_docs, engine=EMBEDDINGS_ENGINE)\n",
+    "\n",
+    "# train/test split\n",
+    "X_train, X_test, y_train, y_test = train_test_split(all_embeddings, all_labels, test_size=0.2, random_state=42)\n",
+    "\n",
+    "# train classifier\n",
+    "clf = MLPClassifier(hidden_layer_sizes=(100, 100), max_iter=1000, alpha=1e-4,\n",
+    "                    solver='sgd', verbose=10, tol=1e-4, random_state=1,\n",
+    "                    learning_rate_init=.1)\n",
+    "clf.fit(X_train, y_train)\n",
+    "\n",
+    "# predict on test set\n",
+    "y_pred = clf.predict(X_test)\n",
+    "\n",
+    "# evaluate\n",
+    "print(accuracy_score(y_test, y_pred))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "New method: split the texts using a sliding window function and embed them separately"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# fft classification with sliding windows\n",
+    "\n",
+    "def split_text(text, segment_length=40, overlap_percent=0.5):\n",
+    "    # text: a string containing the corpus of text\n",
+    "    # segment_length: an integer indicating the number of words in each segment\n",
+    "    # overlap_percent: a float between 0 and 1 indicating the percentage of overlap between segments\n",
+    "    # returns: a list of strings containing the overlapping segments\n",
+    "\n",
+    "    # check if the parameters are valid\n",
+    "    if not isinstance(text, str):\n",
+    "        raise TypeError(\"text must be a string\")\n",
+    "    if not isinstance(segment_length, int) or segment_length <= 0:\n",
+    "        raise ValueError(\"segment_length must be a positive integer\")\n",
+    "    if not isinstance(overlap_percent, float) or overlap_percent < 0 or overlap_percent > 1:\n",
+    "        raise ValueError(\"overlap_percent must be a float between 0 and 1\")\n",
+    "\n",
+    "    # initialize an empty list to store the segments\n",
+    "    segments = []\n",
+    "\n",
+    "    # split the text into words by whitespace\n",
+    "    words = text.split()\n",
+    "\n",
+    "    # calculate the number of words to skip for each segment\n",
+    "    skip = int(segment_length * (1 - overlap_percent))\n",
+    "\n",
+    "    # loop through the words with a sliding window\n",
+    "    for i in range(0, len(words), skip):\n",
+    "        # get the current segment by slicing the words\n",
+    "        segment = \" \".join(words[i:i+segment_length])\n",
+    "        # append the segment to the list\n",
+    "        segments.append(segment)\n",
+    "\n",
+    "    return segments\n",
+    "\n",
+    "all_docs_paras = [split_text(doc, segment_length=40) for doc in all_docs]\n",
+    "\n",
+    "# remove any empty paragraphs\n",
+    "all_docs_paras = [[para for para in paras if para] for paras in all_docs_paras]\n",
+    "# remove any '' paragraphs\n",
+    "all_docs_paras = [[para for para in paras if para != ''] for paras in all_docs_paras]\n",
+    "\n",
+    "# get embeddings for each paragraph\n",
+    "print('Getting embeddings...')\n",
+    "EMBEDDINGS_ENGINE = \"text-embedding-ada-002\"\n",
+    "all_embeddings_paras = [get_embeddings(paras, engine=EMBEDDINGS_ENGINE) for paras in tqdm(all_docs_paras)]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Apply the Fast Fourier Transform (FFT) to each paragraph to get the frequency domain representation of the text. Apply a simple lowpass filter, then transform back into the time domain with the ISTFT. Then collapse the sequence of embeddings to a single embedding by averaging in the time domain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# convert to numpy arrays\n",
+    "all_embeddings_paras = [np.array(doc) for doc in all_embeddings_paras]\n",
+    "\n",
+    "# get FFTs\n",
+    "def get_fft(embedding):\n",
+    "    return librosa.stft(embedding, n_fft=32, win_length=4)\n",
+    "\n",
+    "# lowpass filter\n",
+    "def lowpass_filter(fft, cutoff=0.5):\n",
+    "    \"\"\"\n",
+    "    Lowpass filter for FFTs\n",
+    "    \"\"\"\n",
+    "    fft = fft.copy()\n",
+    "    fft[:, int(cutoff*fft.shape[1]):] = 0\n",
+    "    return fft\n",
+    "\n",
+    "# convert back to embeddings\n",
+    "def fft_to_embedding(fft):\n",
+    "    return librosa.istft(fft, win_length=4)\n",
+    "\n",
+    "apply_lowpass = True\n",
+    "\n",
+    "# get FFTs\n",
+    "print('Applying FFTs...')\n",
+    "all_embeddings_paras_fft = [get_fft(embedding) for embedding in tqdm(all_embeddings_paras)]\n",
+    "\n",
+    "if apply_lowpass:\n",
+    "    # lowpass filter\n",
+    "    print('Lowpass filtering...')\n",
+    "    all_embeddings_paras_fft = [lowpass_filter(fft) for fft in tqdm(all_embeddings_paras_fft)]\n",
+    "\n",
+    "# convert back to embeddings\n",
+    "print('Converting back to embeddings with ISTFT...')\n",
+    "all_embeddings_paras_lowpass = [fft_to_embedding(fft) for fft in tqdm(all_embeddings_paras_fft)]\n",
+    "\n",
+    "if not apply_lowpass:\n",
+    "    # assert that the embeddings are the same if lowpass filtering is not applied\n",
+    "    assert np.allclose(all_embeddings_paras_lowpass[0], all_embeddings_paras[0])\n",
+    "\n",
+    "# average embeddings\n",
+    "train_embeddings_lowpass_avg = [np.mean(embeddings, axis=0) for embeddings in all_embeddings_paras_lowpass]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Train a second `MLPClassifier` to classify the original documents using the new embeddings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# train/test split\n",
+    "X_train, X_test, y_train, y_test = train_test_split(train_embeddings_lowpass_avg, all_labels, test_size=0.2, random_state=42)\n",
+    "\n",
+    "# train classifier\n",
+    "clf2 = MLPClassifier(hidden_layer_sizes=(100, 100), max_iter=1000, alpha=1e-4,\n",
+    "                    solver='sgd', verbose=10, tol=1e-4, random_state=1,\n",
+    "                    learning_rate_init=.1)\n",
+    "clf2.fit(X_train, y_train)\n",
+    "\n",
+    "# predict on test set\n",
+    "y_pred = clf2.predict(X_test)\n",
+    "\n",
+    "# evaluate\n",
+    "print(accuracy_score(y_test, y_pred))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# results\n",
+    "\n",
+    "- get embeddings for whole text: 97.1% accuracy\n",
+    "- sliding window without lowpass filter: 96% accuracy\n",
+    "- sliding window with lowpass filter @ 0.5: 97.6% accuracy"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "3e67b88d6ad197c9402ec873fcbcf9f15e38aeaf8485f1023dc62e85e716efbf"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#234](https://github.com/openai/openai-cookbook/pull/234)
> **Original author:** @jagilley
> **Originally opened:** 2023-03-16

---

Hey team - here's an example notebook for using signal processing methods to improve the OpenAI embeddings' ability to encode long documents. Full paper can be found here: https://jagilley.github.io/fft-embed.html

Let me know if you have any suggested changes!
