### PR TITLE
adds devcontainer support for file-q-and-a app

### DIFF
--- a/apps/file-q-and-a/nextjs/.devcontainer/Dockerfile
+++ b/apps/file-q-and-a/nextjs/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+ARG VARIANT=16-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:${VARIANT}

--- a/apps/file-q-and-a/nextjs/.devcontainer/devcontainer.json
+++ b/apps/file-q-and-a/nextjs/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "name": "openai-cookbook file-q-and-a",
+    "dockerFile": "Dockerfile",
+    "forwardPorts": [3000]
+}

--- a/apps/file-q-and-a/nextjs/README.md
+++ b/apps/file-q-and-a/nextjs/README.md
@@ -10,6 +10,8 @@ To run the app, you need an OpenAI API key. You can create a new API key [here](
 
 If you don't have Node.js and npm already, install them from [https://nodejs.org/en/download/](https://nodejs.org/en/download/).
 
+Otherwise you can run the project inside a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers). If you are using VS Code, open the Command Pallette (ctrl+shift+p on Windows / cmd+shift+p on Mac), and run the command `Dev Containers: Open Folder in Container`. Then select the folder `apps/file-q-and-a/nextjs`, and VS Code will take care of booting a container with Node.js and npm ready to go. You may need to install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
+
 In your terminal, navigate to the `nextjs` directory of this example app, and then install dependencies:
 
 ```


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#218](https://github.com/openai/openai-cookbook/pull/218)
> **Original author:** @videlalvaro
> **Originally opened:** 2023-03-14

---

Adds a dev container for the nextjs app, to simplify testing the project directly on VS Code.
