### PR TITLE
Handle a null answer from the server.

### DIFF
--- a/apps/file-q-and-a/nextjs-with-flask-server/client/src/components/FileQandAArea.tsx
+++ b/apps/file-q-and-a/nextjs-with-flask-server/client/src/components/FileQandAArea.tsx
@@ -108,14 +108,11 @@ function FileQandAArea(props: FileQandAAreaProps) {
           className="mb-8"
         >
           {/* answer from files */}
-          {answer && (
+          {answer ? (
             <div className="">
               <ReactMarkdown className="prose" linkTarget="_blank">
                 {answer}
               </ReactMarkdown>
-            </div>
-          )}
-
           <Transition
             show={
               props.files.filter((file) =>
@@ -138,6 +135,12 @@ function FileQandAArea(props: FileQandAAreaProps) {
               listExpanded={true}
             />
           </Transition>
+            </div>
+          ) : (
+            <div className="">
+               I did not receive an answer!
+            </div>
+          )}
         </Transition>
       </div>
     </div>


### PR DESCRIPTION
> **Copied from upstream:** [openai/openai-cookbook#184](https://github.com/openai/openai-cookbook/pull/184)
> **Original author:** @sammyjava
> **Originally opened:** 2023-03-05

---

I'm finding that the server sometimes returns a null answer. This crashes the client app. This PR adds logic to spit out the response "I did not receive an answer!" when that happens. It isn't clear to me why the server returns a null answer rather than "I couldn't find the answer to that question in your files." It seems to vary with server restarts.
